### PR TITLE
Fix BitOr calling op_xor

### DIFF
--- a/src/pydsl/compiler.py
+++ b/src/pydsl/compiler.py
@@ -400,7 +400,7 @@ class ToMLIR(ToMLIRBase):
             case ast.BitXor():
                 return left.op_xor(right)
             case ast.BitOr():
-                return left.op_xor(right)
+                return left.op_or(right)
             case ast.And():
                 return left.op_and(right)
             case ast.Or():


### PR DESCRIPTION
I don't think we ever call this code, since our integers don't implement bitwise operations yet, but might as well fix this typo.