### PR TITLE
Support chain assignment

### DIFF
--- a/src/pydsl/frontend.py
+++ b/src/pydsl/frontend.py
@@ -65,9 +65,7 @@ class SupportsCType(Protocol):
         ...
 
     @classmethod
-    def to_CType(
-        cls: type, arg_cont: ArgContainer, pyval: Any
-    ) -> CTypeTree:
+    def to_CType(cls: type, arg_cont: ArgContainer, pyval: Any) -> CTypeTree:
         """
         Take a Python value and convert it to match the types of CType
         """
@@ -769,9 +767,7 @@ compilation may fail entirely.
         mapped_args_ct = [
             (
                 ct,
-                self.val_to_CType(
-                    arg_cont, sig.parameters[key].annotation, a
-                ),
+                self.val_to_CType(arg_cont, sig.parameters[key].annotation, a),
             )
             for ct, key, a in zip(
                 self.get_args_ctypes(f), sig.parameters, args, strict=False

--- a/src/pydsl/memref.py
+++ b/src/pydsl/memref.py
@@ -184,9 +184,7 @@ class UsesRMRD:
                 )
 
     @classmethod
-    def from_CType(
-        cls, arg_cont: ArgContainer, ct: "CTypeTree"
-    ) -> np.ndarray:
+    def from_CType(cls, arg_cont: ArgContainer, ct: "CTypeTree") -> np.ndarray:
         # This requires element_type to be representable with a single ctypes element
         rmd = RankedMemRefDescriptor.from_CType(arg_cont, ct)
         element_ctype = cls.element_type.CType()[0]

--- a/src/pydsl/type.py
+++ b/src/pydsl/type.py
@@ -1336,9 +1336,7 @@ class Slice:
         self.hi = hi
         self.step = step
 
-    def get_args(
-        self, max_size: SupportsIndex
-    ) -> tuple[Index, Index, Index]:
+    def get_args(self, max_size: SupportsIndex) -> tuple[Index, Index, Index]:
         """
         Returns [offset, size, step], which can be used for MLIR functions.
         Returns 0, max_size, 1 instead of None values, respectively.


### PR DESCRIPTION
I found the case when `node.targets` has length not 1 in `visit_Assign` (was reading Python AST documentation earlier). So quickly implemented the correct behaviour. 

Also minor formatting changes since it seems I forgot to run formatter after my previous commit.