### PR TITLE
Add tests to pyproject.toml pythonpath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ addopts = [
     "--import-mode=importlib",
 ]
 pythonpath = [
-  ".", "src",
+  "src", "tests",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This allows `hatch test` to work without including the `tests` directory in the `$PYTHONPATH` environment variable. 