### PR TITLE
Add __class_getitem__ to tensor and memref

### DIFF
--- a/src/pydsl/memref.py
+++ b/src/pydsl/memref.py
@@ -587,26 +587,24 @@ class MemRef(typing.Generic[DType, *Shape], UsesRMRD):
         raise TypeError("cannot store to a slice of a MemRef")
 
     @classmethod
+    def __class_getitem__(cls, args: tuple):
+        if not isinstance(args, tuple):
+            args = (args,)
+
+        return cls.class_factory(tuple(args[1:]), args[0])
+
+    @classmethod
     def on_class_getitem(
         cls, visitor: ToMLIRBase, slice: ast.AST
     ) -> SubtreeOut:
-        # TODO: this looks boilerplatey, maybe a helper function that takes
-        # in a typing.Generic and do automatic binding of arguments?
         match slice:
             case ast.Tuple(elts=elts):
-                args = [visitor.resolve_type_annotation(e) for e in elts]
+                args = tuple(visitor.resolve_type_annotation(e) for e in elts)
             case t:
-                args = [visitor.resolve_type_annotation(t)]
+                args = (visitor.resolve_type_annotation(t),)
 
-        if len(args) < 2:
-            raise TypeError(
-                f"MemRef expected at least 2 Generic arguments, got {args}"
-            )
-
-        dtype = args[0]
-        shape = args[1:]
-
-        return cls.class_factory(tuple(shape), dtype)
+        # Equivalent to cls.__class_getitem__(args)
+        return cls[args]
 
     def lower(self) -> tuple[Value]:
         return (self.value,)

--- a/tests/e2e/test_tensor.py
+++ b/tests/e2e/test_tensor.py
@@ -11,11 +11,11 @@ from pydsl.type import F64, F32, SInt32, UInt64, Index
 from pydsl.tensor import Tensor, TensorFactory
 from helper import failed_from, compilation_failed_from, multi_arange, run
 
-TensorF32_2 = TensorFactory((DYNAMIC, DYNAMIC), F32)
-TensorF32_3 = TensorFactory((DYNAMIC, DYNAMIC, DYNAMIC), F32)
-TensorI32_2 = TensorFactory((DYNAMIC, DYNAMIC), SInt32)
-TensorI32_3 = TensorFactory((DYNAMIC, DYNAMIC, DYNAMIC), SInt32)
-TensorF64_1 = TensorFactory((DYNAMIC,), F64)
+TensorF32_2 = Tensor[F32, DYNAMIC, DYNAMIC]
+TensorF32_3 = Tensor[F32, DYNAMIC, DYNAMIC, DYNAMIC]
+TensorI32_2 = Tensor[SInt32, DYNAMIC, DYNAMIC]
+TensorI32_3 = Tensor[SInt32, DYNAMIC, DYNAMIC, DYNAMIC]
+TensorF64_1 = Tensor[F64, DYNAMIC]
 TensorF64_2 = TensorFactory((DYNAMIC, DYNAMIC), F64)
 TensorF64_4 = TensorFactory((DYNAMIC, DYNAMIC, DYNAMIC, DYNAMIC), F64)
 TensorU64_2 = TensorFactory((DYNAMIC, DYNAMIC), UInt64)


### PR DESCRIPTION
This allows the creation of `Tensor` and `MemRef` subclasses using the syntax `MemRef[F32, 10, 32]` even outside of a PyDSL context.