### PR TITLE
Disable CI on pushes to branches other than main

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch: # can trigger manually
   pull_request: # can trigger on pull requests
   push: # can trigger on pushes
+    branches:
+      - main
 
 jobs:
   autotest:


### PR DESCRIPTION
Now CI will not be triggered on pushes to branches other than main. CI is still triggered when pull request is created. You can still launch CI manually in the Actions tab on Github website.