### PR TITLE
Implement inline functions

### DIFF
--- a/src/pydsl/analysis/names.py
+++ b/src/pydsl/analysis/names.py
@@ -3,8 +3,8 @@ from collections.abc import Iterable
 from functools import cache
 
 """
-The Used and Bound analysis attempts to emulate Python's name resolution behavior as closely as
-possible.
+The Used and Bound analysis attempts to emulate Python's name resolution
+behavior as closely as possible.
 It is NOT a runtime frames stack, but rather a stack of nested function scope
 and the variables that they define.
 

--- a/src/pydsl/compiler.py
+++ b/src/pydsl/compiler.py
@@ -336,7 +336,7 @@ class ToMLIR(ToMLIRBase):
                 # adds the AST as the first parameter, similar to
                 # how self works in Python
                 return handle_CompileTimeCallable(
-                    self, value, prefix_args=[operand]
+                    self, value, prefix_args=(operand,)
                 )
 
             case _:
@@ -785,7 +785,7 @@ class ToMLIR(ToMLIRBase):
         for item in node.items:
             if type(call := item.context_expr) is ast.Call:
                 return handle_CompileTimeCallable(
-                    self, call, prefix_args=[node.body]
+                    self, call, prefix_args=(node.body,)
                 )
             raise NotImplementedError(
                 "with statement currently only allows calls as contexts"

--- a/src/pydsl/macro.py
+++ b/src/pydsl/macro.py
@@ -266,7 +266,9 @@ class CallMacro(Macro):
             bound_args = signature.bind(*args, **keywords)
             binding = bound_args.arguments
         except TypeError as e:
-            raise TypeError(f"error occured when calling a macro: {e}") from e
+            raise TypeError(
+                f"couldn't bind arguments when calling a macro: {e}"
+            ) from e
 
         for name in binding.keys():
             # compile each argument value according to its argtype hinting


### PR DESCRIPTION
Closes https://github.com/Huawei-CPLLab/PyDSL/issues/21.

Necessary for adding proper support for `linalg.reduce`.

Maybe I will write documentation a bit later.

The main feature of inline functions that could still be improved is scoping; right now, it has the same scoping rules as a nested function in Python, which is probably not exactly what we want. 