### PR TITLE
Make it easier to subclass ToMLIR and CompilationTarget

### DIFF
--- a/src/pydsl/compiler.py
+++ b/src/pydsl/compiler.py
@@ -793,6 +793,7 @@ class ToMLIR(ToMLIRBase):
         created. Subclasses can override this method to register their own
         dialects.
         """
+        pass
 
     @contextmanager
     def compile(


### PR DESCRIPTION
For `ToMLIR`, added `customize_context` method.

For `CompilationTarget`, moved some of the logic of `check_module_support` to `get_supported_dialects`.

This is useful for downstream changes and makes it easier to subclass `ToMLIR` and `CompilationTarget`/`CTarget`.