### PR TITLE
Use correct scope for inline functions

### DIFF
--- a/dev/dev_docs.md
+++ b/dev/dev_docs.md
@@ -195,18 +195,21 @@ calls its `on_Call` method, but calling it from compiler code directly calls
 its  `__call__` method (which is `__init__` for a class).
 - The required arguments and the exact behaviour can thus be slightly
 different.
-    - E.g. when calling a `CallMacro` from compiler code (like from another
-    `CallMacro`), you must manually pass in `visitor` as the first argument.
+    - E.g. when calling a `CallMacro` or `InlineFunction` from compiler code
+    (like from another `CallMacro`), you must manually pass in `visitor` as the
+    first argument.
 - Sometimes calling a function-like object from compiler code and user code is
 basically the same, which is nice.
-    - The `on_Call` and `__call__` methods of `InlineFunction`s are designed
-    specifically so that calling them from user code and compiler code is the
-    same (no extra arguments need to be passed in either case).
     - Casting of scalar types works directly in both user and compiler code:
     `UInt32(UInt16(123))` is valid in both PyDSL and Python.
-        - Maybe the behaviour from casting within the compiler will become
+        - Maybe the behaviour for casting within the compiler will become
         a bit different depending on how
         https://github.com/Huawei-CPLLab/PyDSL/issues/19 is resolved.
+- When writing something similar that you want to be able to call from both
+PyDSL code and compiler code, the main way to decide what should go in
+`on_Call` and what should go in `__call__` is based on what logic needs to be
+done only when called from PyDSL, and what logic needs to be done for both
+being called from PyDSL and Python.
 
 # Circular import
 

--- a/tests/e2e/test_func.py
+++ b/tests/e2e/test_func.py
@@ -1,6 +1,7 @@
+import numpy as np
+import pytest
 from typing import Any, TypeAlias, TypeVar
 
-import numpy as np
 from pydsl.frontend import compile
 from pydsl.func import InlineFunction
 from pydsl.macro import CallMacro, Compiled
@@ -488,21 +489,56 @@ def test_inline_func_pos_as_kw_only():
             return inline_f(x, y)
 
 
-# In the future, we should make this NameError, but for now, this is correct
-def test_inline_func_scope():
+@pytest.mark.xfail(reason="https://github.com/Huawei-CPLLab/PyDSL/issues/93")
+def test_inline_func_scope_good():
+    c = 56
+
+    @InlineFunction.generate()
+    def inline_f(a: UInt32, b: UInt32) -> UInt32:
+        d = a + b + c
+        return d * 3
+
+    @compile()
+    def f(a: UInt32, b: UInt32) -> Tuple[UInt32, UInt32]:
+        res1 = inline_f(a, b)
+        c = 987
+        res2 = inline_f(a, b)
+        return res1, res2
+
+    cor_res = (12 + 34 + 56) * 3
+    assert f(12, 34) == (cor_res, cor_res)
+
+
+def test_inline_func_scope_bad():
     @InlineFunction.generate()
     def inline_f(a, b) -> Any:
         d = a + b + c
         return d * 3
 
+    with compilation_failed_from(NameError):
+
+        @compile()
+        def f(a: UInt32, b: UInt32, c: UInt32) -> UInt32:
+            return inline_f(a, b)
+
+
+def test_inline_func_custom_scope():
+    c = 999
+
+    @InlineFunction.generate(vars={"c": 56, "d": 78})
+    def inline_f(a, b) -> Any:
+        return a + b + c + d
+
     @compile()
-    def f(a: UInt32, b: UInt32, c: UInt32) -> UInt32:
+    def f(a: UInt32, b: UInt32) -> UInt32:
         return inline_f(a, b)
 
-    assert f(12, 34, 56) == (12 + 34 + 56) * 3
+    assert f(12, 34) == 12 + 34 + 56 + 78
 
 
-def test_inline_func_unbounded_local():
+def test_inline_func_unbound_local():
+    c = 56
+
     # Yes, adding c = 1 is supposed to make this fail because Python is a
     # well-designed language
     @InlineFunction.generate()
@@ -514,7 +550,7 @@ def test_inline_func_unbounded_local():
     with compilation_failed_from(UnboundLocalError):
 
         @compile()
-        def f(a: UInt32, b: UInt32, c: UInt32) -> UInt32:
+        def f(a: UInt32, b: UInt32) -> UInt32:
             return inline_f(a, b)
 
 
@@ -556,5 +592,7 @@ if __name__ == "__main__":
     run(test_inline_func_kw_args)
     run(test_inline_func_bad_kw_arg)
     run(test_inline_func_pos_as_kw_only)
-    run(test_inline_func_scope)
-    run(test_inline_func_unbounded_local)
+    run(test_inline_func_scope_good)
+    run(test_inline_func_scope_bad)
+    run(test_inline_func_custom_scope)
+    run(test_inline_func_unbound_local)


### PR DESCRIPTION
Changes the `@InlineFunction.generate()` decorator to accept an argument `vars` that defines what variables is should have access to. By default, it is `builtins | globals | locals` of the scope that defines the inline function. This is basically the same as `frontend.compile`. Previously, it used to use the scope where the inline function was called, which is not ideal.

Closes https://github.com/Huawei-CPLLab/PyDSL/issues/70.

The changes in `dev_docs.md` aren't actually related to these changes; what I wrote originally was incorrect.