### PR TITLE
Add templates to PyDSL

### DIFF
--- a/src/pydsl/frontend.py
+++ b/src/pydsl/frontend.py
@@ -1525,3 +1525,103 @@ def compile(
         return cm
 
     return payload
+
+
+class Template:
+    """
+    A class which supports compilation using type parameters
+    provided by the user. It works by deferring compilation until
+    type parameters are known.
+
+    This class holds a python function and all the information required
+    to compile it when the type arguments are known.
+
+    When subscripted with type arguments, the function is compiled with
+    the parameters substituted for the type arguments in the context.
+    """
+
+    _f: Callable
+    _tparams: list[ast.TypeVar]
+    _context: typing.Optional[dict[str, Any]]
+    _settings: dict
+
+    def __init__(
+        self,
+        f: Callable,
+        tparams: list[ast.TypeVar],
+        context: typing.Optional[dict[str, Any]],
+        settings: dict,
+    ):
+        self._f = f
+        self._tparams = tparams
+        self._context = context
+        self._settings = settings
+
+    @cache
+    def __call__(self, *args, **kwargs):
+        if self._tparams:
+            raise NotImplementedError(
+                "type inference for templates not yet implemented"
+            )
+
+        return compile(self._context, **self._settings)(self._f)(
+            *args, **kwargs
+        )
+
+    @cache
+    def __getitem__(self, template_args):
+        if not isinstance(template_args, tuple):
+            template_args = (template_args,)
+
+        if len(template_args) != len(self._tparams):
+            raise TypeError("incorrect number of template arguments")
+
+        for ta, tp in zip(template_args, self._tparams):
+            self._context[tp.name] = ta
+
+        return compile(self._context, **self._settings)(self._f)
+
+
+def template(context: typing.Optional[dict[str, Any]] = None, **settings):
+    """
+    A decorator which supports generic functions with type parameters.
+
+    This decorator can be used instead of @compile on a PyDSL function,
+    and it will allow the function to take template parameters in square
+    brackets. Any arguments passed to the decorator itself will be
+    forwarded to @compile.
+
+    The general syntax is as follows:
+    ```
+    @template(...) # same arguments are compile
+    def my_func[T, ...](a: T, ...): # T, ... is a list of template parameters
+        ... # do stuff
+
+    my_func[SInt32, ...](3, ...) # compilation occurs here
+    ```
+
+    For example
+    @template()
+    def my_func[T](a: T) -> T:
+        return a
+
+    my_func[SInt32](3) # returns 3
+    my_func[F32](3.5) # return 3.5
+    """
+    if context is None:
+        f_back = inspect.currentframe().f_back
+        context = f_back.f_builtins | f_back.f_globals | f_back.f_locals
+
+    def payload(f: Callable) -> CompiledFunction:
+        func_ast: AST = ast.parse(textwrap.dedent(inspect.getsource(f)))
+
+        assert isinstance(func_ast, ast.Module)
+        func_ast = func_ast.body[0]
+        if not isinstance(func_ast, ast.FunctionDef):
+            raise NotImplementedError(
+                "right now, templates only support functions, not classes"
+            )
+
+        return Template(f, func_ast.type_params, context, settings)
+
+    return payload

--- a/tests/e2e/test_templates.py
+++ b/tests/e2e/test_templates.py
@@ -1,0 +1,70 @@
+import numpy as np
+import math
+
+from pydsl.arith import min
+from pydsl.frontend import template
+from pydsl.tensor import Tensor
+from pydsl.type import F32, F64, Index, SInt8, UInt64
+
+from helper import failed_from, run
+
+
+def test_basic_template():
+    @template()
+    def calc[T](a: T) -> T:
+        return a * a
+
+    assert math.isclose(calc[F32](3.0), 9.0)
+    assert calc[SInt8](4) == 16
+    assert calc[UInt64](9) == 81
+    assert math.isclose(calc[F32](1.5), 2.25)
+    assert calc[SInt8](-4) == 16
+    assert calc[UInt64](17) == 289
+
+
+def test_no_params():
+    @template()
+    def calc(a: UInt64) -> UInt64:
+        return a + a
+
+    assert calc(3) == 6
+
+
+def test_template_tensor():
+    @template()
+    def calc[T, N, M](mat: Tensor[T, N, M]) -> Tensor[T, N, M]:
+        n = Index(N)
+        m = Index(M)
+        mat[n - 1, m - 1] = 1
+        return mat
+
+    arr = calc[F32, 10, 5](np.zeros((10, 5), dtype=np.float32))
+    assert math.isclose(arr[9][4], 1.0)
+    arr = calc[F64, 1, 40](np.zeros((1, 40), dtype=np.float64))
+    assert math.isclose(arr[0][39], 1.0)
+
+
+def test_call_macro():
+    @template()
+    def calc[T](a: T, b: T) -> T:
+        return min(a, b)
+
+    assert calc[SInt8](3, 4) == 3
+    assert calc[Index](420, 69) == 69
+
+
+def test_type_inference():
+    @template()
+    def calc[T](a: T) -> T:
+        return a
+
+    with failed_from(NotImplementedError):
+        assert calc(3) == 3
+
+
+if __name__ == "__main__":
+    run(test_basic_template)
+    run(test_no_params)
+    run(test_template_tensor)
+    run(test_call_macro)
+    run(test_type_inference)


### PR DESCRIPTION
Add templates to PyDSL, we do not yet support conditionals based on type, only environment substitution.