### PR TITLE
fix #34: proper casting function arg and ret

### DIFF
--- a/src/pydsl/func.py
+++ b/src/pydsl/func.py
@@ -596,8 +596,13 @@ class Function(FunctionLike):
         self = attr_chain[-1]
         prefix_args = [visitor.visit(a) for a in prefix_args]
         args = [visitor.visit(a) for a in node.args]
+        args = [
+            a if isinstance(a, t) else t(a) for t, a in zip(self.argst, args)
+        ]
 
-        return func.CallOp(self.val, lower_flatten([*prefix_args, *args]))
+        rst = func.CallOp(self.val, lower_flatten([*prefix_args, *args]))
+
+        return self.rett(rst) if self.rett is not None else rst
 
 
 class TransformSequence(FunctionLike):

--- a/src/pydsl/type.py
+++ b/src/pydsl/type.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import collections.abc as cabc
 import ctypes
@@ -1218,10 +1220,12 @@ class Tuple(typing.Generic[*DTypes]):
     # TODO: this will temporarily perform casting of other tuples
     # but later we will need to do a major refactor that shifts this behavior
     # to a dedicated member function called `cast`.
-    def __init__(self, iterable: typing.Union[cabc.Iterable, "Tuple"]):
+    def __init__(self, iterable: cabc.Iterable | Tuple | mlir.OpView):
         # this is the very bad casting code mentioned in the todo
         if isinstance(iterable, Tuple):
             iterable = iterable.value
+        elif isinstance(iterable, mlir.OpView):
+            iterable = iterable.results
 
         error = TypeError(
             f"Tuple with dtypes {[t.__name__ for t in self.dtypes]} "

--- a/tests/e2e/test_func.py
+++ b/tests/e2e/test_func.py
@@ -264,6 +264,55 @@ def test_body_func():
     assert CallTest.f1() == 12
 
 
+def test_arg_cast():
+    @compile()
+    class Mod:
+        def f(a: UInt32) -> UInt64:
+            return a
+
+        def g(a: UInt16) -> UInt64:
+            return f(a)
+
+    assert Mod.g(42) == 42
+
+
+def test_ret_cast():
+    @compile()
+    class Mod:
+        def f(a: UInt32) -> UInt32:
+            return a
+
+        def g(a: UInt32) -> UInt64:
+            return f(a)
+
+    assert Mod.g(42) == 42
+
+
+def test_ret_tuple():
+    @compile()
+    class Mod:
+        def f(a: UInt32) -> Tuple[UInt32, UInt32]:
+            return a, a + 1
+
+        def g(a: UInt32) -> UInt64:
+            (b, c) = f(a)
+            return c
+
+    assert Mod.g(42) == 43
+
+
+def test_multi_func_cast():
+    @compile()
+    class Mod:
+        def my_add(a: UInt16, b: UInt16) -> UInt64:
+            return a + b
+
+        def triple_add(a: UInt16, b: UInt16, c: UInt16) -> UInt64:
+            return my_add(a, b) + c
+
+    assert Mod.triple_add(20000, 30000, 40000) == 20000 + 30000 + 40000
+
+
 def test_recursion():
     @compile()
     def recursion(i: Index, m: MemRef[UInt16, 5]):
@@ -494,6 +543,10 @@ if __name__ == "__main__":
     run(test_return_casting_tuple_2)
     run(test_module_call_basic)
     run(test_body_func)
+    run(test_arg_cast)
+    run(test_ret_cast)
+    run(test_ret_tuple)
+    run(test_multi_func_cast)
     run(test_recursion)
     run(test_inline_func_basic)
     run(test_inline_func_cast)


### PR DESCRIPTION
fix #34: proper casting function arg and ret