### PR TITLE
Tensor empty and full, new alloc syntax and memory spaces

### DIFF
--- a/src/pydsl/compiler.py
+++ b/src/pydsl/compiler.py
@@ -28,6 +28,7 @@ from pydsl.func import Function, TransformSequence
 # E.g. CalMacro implements the CompileTimeCallable protocol.
 # E.g. Addition in Int and Float uses the op_add magic function.
 from pydsl.protocols import (
+    canonicalize_args,
     CompileTimeClassSliceable,
     CompileTimeIterable,
     CompileTimeSliceable,
@@ -912,6 +913,7 @@ class Dialect:
     # despite being initialized twice.
     # Whereas not doing caching would result in False as they would be
     # two different objects both with name == "arith".
+    @canonicalize_args
     @cache
     def __new__(cls, *args, **kwargs):
         return super(Dialect, cls).__new__(cls)

--- a/src/pydsl/func.py
+++ b/src/pydsl/func.py
@@ -21,6 +21,7 @@ from pydsl.protocols import (
     Lowerable,
     SubtreeOut,
     ToMLIRBase,
+    canonicalize_args,
     lower,
     lower_flatten,
 )
@@ -158,6 +159,7 @@ class FunctionLike(typing.Generic[ArgsT, RetT], ABC):
         return f
 
     @classmethod
+    @canonicalize_args
     @cache
     def node_to_header(
         cls, visitor: ToMLIRBase, node: ast.FunctionDef
@@ -196,6 +198,7 @@ class FunctionLike(typing.Generic[ArgsT, RetT], ABC):
         return cls.class_factory(args, ret)
 
     @classmethod
+    @canonicalize_args
     @cache
     def class_factory(
         cls,

--- a/src/pydsl/gpu.py
+++ b/src/pydsl/gpu.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+from mlir.ir import AttrBuilder
+import mlir.dialects.gpu as gpu
+
+from pydsl.memref import MemorySpace
+
+
+class GPU_AddrSpace(MemorySpace, Enum):
+    Global = gpu.AddressSpace.Global
+    Workgroup = gpu.AddressSpace.Workgroup
+    Private = gpu.AddressSpace.Private
+
+    def lower(self):
+        return (
+            AttrBuilder.get("GPU_AddressSpaceAttr")(self.value, context=None),
+        )

--- a/src/pydsl/linalg.py
+++ b/src/pydsl/linalg.py
@@ -304,7 +304,7 @@ def batch_matmul(visitor: "ToMLIRBase", x: Compiled, y: Compiled):
 
 
 @CallMacro.generate()
-def fill(visitor: "ToMLIRBase", c: Compiled, x: Compiled) -> Tensor | MemRef:
+def fill(visitor: "ToMLIRBase", x: Compiled, c: Compiled) -> Tensor | MemRef:
     """
     Fill a MemRef/Tensor with the single value c.
     If x is a MemRef, it is modified in-place.

--- a/src/pydsl/memref.py
+++ b/src/pydsl/memref.py
@@ -20,7 +20,13 @@ from mlir.ir import (
 
 from pydsl.affine import AffineContext, AffineMapExpr, AffineMapExprWalk
 from pydsl.macro import CallMacro, Compiled, Evaluated
-from pydsl.protocols import ArgContainer, SubtreeOut, ToMLIRBase, lower
+from pydsl.protocols import (
+    ArgContainer,
+    canonicalize_args,
+    SubtreeOut,
+    ToMLIRBase,
+    lower,
+)
 from pydsl.type import (
     Index,
     Lowerable,
@@ -384,6 +390,7 @@ class MemRef(typing.Generic[DType, *Shape], UsesRMRD):
     ]
 
     @staticmethod
+    @canonicalize_args
     @cache
     def class_factory(
         shape: tuple[int],

--- a/src/pydsl/memref.py
+++ b/src/pydsl/memref.py
@@ -1,9 +1,11 @@
 import ast
 import ctypes
 import typing
+
 from collections.abc import Callable, Iterable
 from ctypes import POINTER, c_void_p
 from dataclasses import dataclass
+from enum import Enum
 from functools import cache
 from typing import TYPE_CHECKING, Final
 
@@ -25,7 +27,6 @@ from pydsl.protocols import (
     canonicalize_args,
     SubtreeOut,
     ToMLIRBase,
-    lower,
 )
 from pydsl.type import (
     Index,
@@ -53,6 +54,31 @@ RuntimeMemrefShape = list[int | Value]
 # based on example in PEP 646: https://peps.python.org/pep-0646/
 DType = typing.TypeVar("DType")
 Shape = typing.TypeVarTuple("Shape")
+
+
+class MemorySpace(Enum):
+    """
+    Superclass for memory spaces. Mostly used for making type-hints nicer and
+    type checking. It would probably make more sense for this to be an Enum
+    with 1 element, or an ABC, but neither of those are possible, so we use an
+    Enum with 0 elements instead.
+
+    Subclasses should implement lower to define what Attribute object in MLIR
+    they correspond to. lower_class is only defined so that this is considered
+    a Lowerable.
+    """
+
+    def lower_class(cls):
+        raise AssertionError(
+            f"class of {cls.__qualname__} cannot be lowered, only its "
+            f"instances"
+        )
+
+    def lower(self) -> tuple[mlir.Attribute | None]:
+        raise AssertionError(
+            "MemorySpace.lower should never be called, subclasses of "
+            "MemorySpace should define their own lower methods"
+        )
 
 
 @dataclass
@@ -372,13 +398,12 @@ class MemRef(typing.Generic[DType, *Shape], UsesRMRD):
     bytes.
     """
 
-    # Only strides is allowed to be None. If anything else remains None,
-    # something has gone wrong.
     value: Value
-    shape: tuple[int] = None
-    element_type: Lowerable = None
-    offset: int = None
-    strides: tuple[int] | None = None
+    shape: tuple[int]
+    element_type: Lowerable
+    offset: int
+    strides: tuple[int] | None
+    memory_space: MemorySpace | None
 
     _default_subclass_name = "AnnonymousMemRefSubclass"
     _supported_mlir_type = [
@@ -399,7 +424,8 @@ class MemRef(typing.Generic[DType, *Shape], UsesRMRD):
         *,
         offset: int = 0,
         strides: tuple[int] | None = None,
-        name=_default_subclass_name,
+        memory_space: MemorySpace | None = None,
+        name: str = _default_subclass_name,
     ):
         """
         Create a new subclass of MemRef with the specified dimensions and type.
@@ -428,6 +454,27 @@ class MemRef(typing.Generic[DType, *Shape], UsesRMRD):
                 f"MemRef requires shape to be iterable, got {type(shape)}"
             )
 
+        if strides is not None:
+            strides = tuple(strides)
+
+            if len(shape) != len(strides):
+                raise ValueError(
+                    f"shape and strides must have the same length, got ",
+                    f"{repr(shape)} and {repr(strides)}",
+                )
+        else:
+            if offset != 0:
+                raise ValueError(
+                    f"offset must be zero for a non-strided layout, got "
+                    f"{offset}"
+                )
+
+        if not isinstance(memory_space, (MemorySpace, type(None))):
+            raise TypeError(
+                f"MemRef memory_space must be an instance of MemorySpace or ",
+                f"None, got {type(memory_space)}",
+            )
+
         return type(
             name,
             (MemRef,),
@@ -435,7 +482,8 @@ class MemRef(typing.Generic[DType, *Shape], UsesRMRD):
                 "shape": tuple(shape),
                 "element_type": element_type,
                 "offset": int(offset),
-                "strides": None if strides is None else tuple(strides),
+                "strides": strides,
+                "memory_space": memory_space,
             },
         )
 
@@ -635,19 +683,25 @@ class MemRef(typing.Generic[DType, *Shape], UsesRMRD):
                 e.add_note(f"hint: class name is {clsname}")
             raise e
 
-        if cls.strides is None:
-            return (
-                MemRefType.get(
-                    list(cls.shape), lower_single(cls.element_type)
-                ),
-            )
-        else:
-            layout = StridedLayoutAttr.get(cls.offset, list(cls.strides))
-            return (
-                MemRefType.get(
-                    list(cls.shape), lower_single(cls.element_type), layout
-                ),
-            )
+        layout = (
+            None
+            if cls.strides is None
+            else StridedLayoutAttr.get(cls.offset, list(cls.strides))
+        )
+        memory_space = (
+            None
+            if cls.memory_space is None
+            else lower_single(cls.memory_space)
+        )
+
+        return (
+            MemRefType.get(
+                list(cls.shape),
+                lower_single(cls.element_type),
+                layout,
+                memory_space,
+            ),
+        )
 
     @property
     def runtime_shape(self) -> RuntimeMemrefShape:
@@ -671,122 +725,94 @@ class MemRef(typing.Generic[DType, *Shape], UsesRMRD):
 MemRefFactory = MemRef.class_factory
 
 
-def verify_memory(mem: MemRef):
-    if not isinstance(mem, MemRef):
-        raise TypeError(
-            f"the type being allocated must be a subclass of MemRef, got {mem}"
-        )
-
-
-def verify_memory_type(mtype: type[MemRef]):
-    if not issubclass(mtype, MemRef):
-        raise TypeError(
-            f"the type being allocated must be a subclass of MemRef, got "
-            f"{mtype}"
-        )
-
-
-def verify_dynamic_sizes(mtype: type[MemRef], dynamic_sizes: Tuple) -> None:
-    dynamic_sizes = lower(dynamic_sizes)
-
-    # TODO: does this check do anything, since lower returns a tuple?
-    if not isinstance(dynamic_sizes, Iterable):
-        raise TypeError(f"{repr(dynamic_sizes)} is not iterable")
-
-    if (actual_dyn := len(dynamic_sizes)) != (
-        target_dyn := mtype.shape.count(DYNAMIC)
-    ):
-        raise ValueError(
-            f"MemRef has {target_dyn} dynamic dimensions to be filled, "
-            f"but alloc/alloca received {actual_dyn}"
-        )
-
-
-def verify_dynamic_symbols(
-    mtype: type[MemRef], dynamic_symbols: Tuple
-) -> None:
-    dynamic_symbols = lower(dynamic_symbols)
-
-    # TODO: does this check do anything, since lower returns a tuple?
-    if not isinstance(dynamic_symbols, Iterable):
-        raise TypeError(f"{repr(dynamic_symbols)} is not iterable")
-
-    if (actual_dyn := len(dynamic_symbols)) != (
-        target_dyn := 0
-        if mtype.strides is None
-        else mtype.strides.count(DYNAMIC)
-    ):
-        raise ValueError(
-            f"MemRef has {target_dyn} dynamic strides to be filled, "
-            f"but alloc/alloca received {actual_dyn}"
-        )
-
-
 def _alloc_generic(
     visitor: ToMLIRBase,
-    mtype: Compiled,
-    dynamic_sizes: Compiled,
-    dynamic_symbols: Compiled,
-    alloc_func: Callable[..., SubtreeOut],
+    alloc_func: Callable,
+    shape: Compiled,
+    dtype: Evaluated,
+    memory_space: MemorySpace | None,
+    alignment: int | None,
 ) -> SubtreeOut:
     """
-    Does the logic required for alloc/alloca. It was silly having
-    two functions that differed by only one character. alloc_func
-    should be memref.alloc or memref.alloca.
+    Does the logic required for alloc/alloca. It was silly having two functions
+    that differed by only one character. alloc_func should be memref.alloc or
+    memref.alloca. Currently only supports allocating non-strided MemRefs of
+    default layout.
     """
-    if dynamic_sizes is None:
-        dynamic_sizes = Tuple.from_values(visitor, *())
+    # NOTE: the dynamic_symbols parameter of memref.alloc is relevant for
+    # allocating MemRefs with an affine map layout. MLIR also supports
+    # allocating a strided MemRef, you simply change m_type to be a strided
+    # MemRef type. However, it seems we don't know how to lower such
+    # allocations from MLIR -> LLVMIR, so this feature is not implemented now.
+    # If this feature is implemented in the future, you can steal
+    # test_alloca_strided test case from an older version of test_memref.py
+    # (although that uses slightly different syntax).
 
-    if dynamic_symbols is None:
-        dynamic_symbols = Tuple.from_values(visitor, *())
-
-    verify_memory_type(mtype)
-
-    if mtype.strides is not None:
-        raise NotImplementedError(
-            "allocating MemRefs with a strided layout is currently"
-            "not supported, since there seems to be no way to lower"
-            "the resulting MLIR to LLVMIR. Allocate a MemRef with"
-            "consecutive memory instead"
+    if not isinstance(shape, Tuple):
+        raise TypeError(
+            f"shape should be a Tuple, got {type(shape).__qualname__}"
         )
 
-    verify_dynamic_sizes(mtype, dynamic_sizes)
-    verify_dynamic_symbols(mtype, dynamic_symbols)
-    dynamic_sizes = [lower_single(Index(i)) for i in lower(dynamic_sizes)]
-    dynamic_symbols = [lower_single(Index(i)) for i in lower(dynamic_symbols)]
+    if not isinstance(alignment, (int, type(None))):
+        raise TypeError(
+            f"alignment must be int or None, got {type(alignment)}"
+        )
 
-    return mtype(
-        alloc_func(lower_single(mtype), dynamic_sizes, dynamic_symbols)
+    if alignment is not None and alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+
+    shape = shape.as_iterable(visitor)
+    static_shape, dynamic_sizes = split_static_dynamic_dims(shape)
+
+    m_type = MemRefFactory(
+        tuple(static_shape), dtype, memory_space=memory_space
+    )
+
+    return m_type(
+        alloc_func(
+            lower_single(m_type),
+            lower_flatten(dynamic_sizes),
+            symbol_operands=[],
+            alignment=alignment,
+        )
     )
 
 
 @CallMacro.generate()
 def alloca(
     visitor: ToMLIRBase,
-    mtype: Compiled,
-    dynamic_sizes: Compiled = None,
-    dynamic_symbols: Compiled = None,
+    shape: Compiled,
+    dtype: Evaluated,
+    *,
+    memory_space: Evaluated = None,
+    alignment: Evaluated = None,
 ) -> SubtreeOut:
     return _alloc_generic(
-        visitor, mtype, dynamic_sizes, dynamic_symbols, memref.alloca
+        visitor, memref.alloca, shape, dtype, memory_space, alignment
     )
 
 
 @CallMacro.generate()
 def alloc(
     visitor: ToMLIRBase,
-    mtype: Compiled,
-    dynamic_sizes: Compiled = None,
-    dynamic_symbols: Compiled = None,
+    shape: Compiled,
+    dtype: Evaluated,
+    *,
+    memory_space: Evaluated = None,
+    alignment: Evaluated = None,
 ) -> SubtreeOut:
     return _alloc_generic(
-        visitor, mtype, dynamic_sizes, dynamic_symbols, memref.alloc
+        visitor, memref.alloc, shape, dtype, memory_space, alignment
     )
 
 
 @CallMacro.generate()
-def dealloc(visitor: ToMLIRBase, mem: Evaluated) -> None:
-    verify_memory(mem)
+def dealloc(visitor: ToMLIRBase, mem: Compiled) -> None:
+    if not isinstance(mem, MemRef):
+        raise TypeError(
+            f"the type being deallocated must be a MemRef, got {type(mem)}"
+        )
+
     return memref.dealloc(lower_single(mem))
 
 

--- a/src/pydsl/tensor.py
+++ b/src/pydsl/tensor.py
@@ -23,7 +23,7 @@ from pydsl.type import (
     SupportsIndex,
     Tuple,
 )
-from pydsl.protocols import SubtreeOut, ToMLIRBase
+from pydsl.protocols import canonicalize_args, SubtreeOut, ToMLIRBase
 
 DYNAMIC = -9223372036854775808
 
@@ -57,6 +57,7 @@ class Tensor(typing.Generic[DType, *Shape], UsesRMRD):
     ]
 
     @staticmethod
+    @canonicalize_args
     @cache
     def class_factory(
         shape: tuple[int], element_type, *, name=_default_subclass_name

--- a/src/pydsl/tensor.py
+++ b/src/pydsl/tensor.py
@@ -1,5 +1,5 @@
 import ast
-import collections.abc as cabc
+from collections.abc import Iterable
 from functools import cache
 import typing
 
@@ -7,23 +7,24 @@ from mlir.dialects import tensor
 import mlir.ir as mlir
 from mlir.ir import DenseI64ArrayAttr, OpView, RankedTensorType, Value
 
+from pydsl.func import InlineFunction
 from pydsl.macro import CallMacro, Compiled, Evaluated
 from pydsl.memref import (
     UsesRMRD,
     RuntimeMemrefShape,
     slices_to_mlir_format,
+    split_static_dynamic_dims,
     subtree_to_slices,
 )
+from pydsl.protocols import canonicalize_args, SubtreeOut, ToMLIRBase
 from pydsl.type import (
     Index,
     Lowerable,
-    lower,
     lower_flatten,
     lower_single,
     SupportsIndex,
     Tuple,
 )
-from pydsl.protocols import canonicalize_args, SubtreeOut, ToMLIRBase
 
 DYNAMIC = -9223372036854775808
 
@@ -42,10 +43,11 @@ class Tensor(typing.Generic[DType, *Shape], UsesRMRD):
     """
 
     value: Value
-    shape: tuple[int] = None
-    element_type: Lowerable = None
-    offset: int = None
-    strides: tuple[int] = None
+    shape: tuple[int]
+    element_type: Lowerable
+    offset: int
+    strides: tuple[int] | None
+
     _default_subclass_name = "AnnonymousTensorSubclass"
     _supported_mlir_type = [
         mlir.IntegerType,
@@ -60,7 +62,7 @@ class Tensor(typing.Generic[DType, *Shape], UsesRMRD):
     @canonicalize_args
     @cache
     def class_factory(
-        shape: tuple[int], element_type, *, name=_default_subclass_name
+        shape: Iterable[int], element_type, *, name=_default_subclass_name
     ):
         """
         Create a new subclass of Tensor dynamically with the specified
@@ -72,7 +74,7 @@ class Tensor(typing.Generic[DType, *Shape], UsesRMRD):
         # store composite types, got {element_type} which lowers to
         # {lower(element_type)}")
 
-        if not isinstance(shape, cabc.Iterable):
+        if not isinstance(shape, Iterable):
             raise TypeError(
                 f"Tensor requires shape to be iterable, got {type(shape)}"
             )
@@ -278,45 +280,37 @@ class Tensor(typing.Generic[DType, *Shape], UsesRMRD):
 TensorFactory = Tensor.class_factory
 
 
-def verify_tensor_type(t_type: type[Tensor]):
-    if not issubclass(t_type, Tensor):
-        raise TypeError(
-            f"the type being allocated must be a subclass of Tensor, got "
-            f"{t_type}"
-        )
-
-
-def verify_dynamics_val(t_type: type[Tensor], dynamics_val: Tuple) -> None:
-    dynamics_val = lower(dynamics_val)
-
-    if not isinstance(dynamics_val, cabc.Iterable):
-        raise TypeError(f"{repr(dynamics_val)} is not iterable")
-
-    if (actual_dyn := len(dynamics_val)) != (
-        target_dyn := t_type.shape.count(DYNAMIC)
-    ):
-        raise ValueError(
-            f"Tensor has {target_dyn} dynamic dimensions to be filled, "
-            f"but emptyOp received {actual_dyn}"
-        )
-
-
 @CallMacro.generate()
 def empty(
-    visitor: ToMLIRBase, t_type: Evaluated, dynamics_val: Compiled = None
+    visitor: ToMLIRBase, shape: Compiled, dtype: Evaluated
 ) -> SubtreeOut:
-    if dynamics_val is None:
-        dynamics_val = Tuple.from_values(visitor, *())
-    verify_tensor_type(t_type)
-    verify_dynamics_val(t_type, dynamics_val)
-    dynamics_val = [lower_single(Index(i)) for i in lower(dynamics_val)]
-    idx = 0
-    orig_shape = t_type.shape
-    shape = [0] * len(orig_shape)
-    for i in range(len(orig_shape)):
-        if orig_shape[i] == DYNAMIC:
-            shape[i] = dynamics_val[idx]
-            idx += 1
-        else:
-            shape[i] = orig_shape[i]
-    return t_type(tensor.empty(shape, lower_single(t_type.element_type)))
+    if not isinstance(shape, Tuple):
+        raise TypeError(f"shape should be a Tuple, got {type(shape)}")
+
+    shape = shape.as_iterable(visitor)
+    static_shape, dynamic_sizes = split_static_dynamic_dims(shape)
+
+    t_type = TensorFactory(tuple(static_shape), dtype)
+    return t_type(
+        tensor.empty(lower_single(t_type), lower_flatten(dynamic_sizes))
+    )
+
+
+# This is not at the top of the file to avoid circular import
+import pydsl.linalg as linalg
+
+
+@InlineFunction.generate()
+def full(shape, val, dtype) -> typing.Any:
+    res = empty(shape, dtype)
+    return linalg.fill(res, val)
+
+
+@InlineFunction.generate()
+def zeros(shape, dtype) -> typing.Any:
+    return full(shape, 0, dtype)
+
+
+@InlineFunction.generate()
+def ones(shape, dtype) -> typing.Any:
+    return full(shape, 1, dtype)

--- a/src/pydsl/type.py
+++ b/src/pydsl/type.py
@@ -31,7 +31,8 @@ from mlir.ir import (
 )
 
 from pydsl.macro import CallMacro, MethodType, Uncompiled
-from pydsl.protocols import ToMLIRBase, ArgContainer
+from pydsl.protocols import ArgContainer, canonicalize_args, ToMLIRBase
+from pydsl.protocols import ArgContainer, canonicalize_args, ToMLIRBase
 
 if TYPE_CHECKING:
     # This is for imports for type hinting purposes only and which can result
@@ -1214,6 +1215,7 @@ class Tuple(typing.Generic[*DTypes]):
     value: tuple
 
     @staticmethod
+    @canonicalize_args
     @cache
     def class_factory(
         dtypes: tuple[type], name=_default_subclass_name

--- a/src/pydsl/vector.py
+++ b/src/pydsl/vector.py
@@ -6,7 +6,12 @@ import mlir.ir as mlir
 from mlir.ir import OpView, Value, VectorType
 
 from pydsl.type import Lowerable
-from pydsl.protocols import lower_single, SubtreeOut, ToMLIRBase
+from pydsl.protocols import (
+    canonicalize_args,
+    lower_single,
+    SubtreeOut,
+    ToMLIRBase,
+)
 
 
 class Vector:
@@ -32,6 +37,7 @@ class Vector:
     ]
 
     @staticmethod
+    @canonicalize_args
     @cache
     def class_factory(
         shape: tuple[int], element_type, *, name=_default_subclass_name

--- a/tests/e2e/test_algorithms.py
+++ b/tests/e2e/test_algorithms.py
@@ -341,7 +341,7 @@ def test_softmax():
     @compile()
     def softmax_memref(arr: MemRef[F64, N, M]) -> MemRef[F64, N, M]:
         reduce_res = alloca(MemRef[F64, N])
-        linalg.fill(neg_inf, reduce_res)
+        linalg.fill(reduce_res, neg_inf)
         linalg.reduce(arith.max, arr, init=reduce_res, dims=[1])
 
         mx = alloca(MemRef[F64, N, M])
@@ -350,7 +350,7 @@ def test_softmax():
 
         linalg.exp(arr)
 
-        linalg.fill(0, reduce_res)
+        linalg.fill(reduce_res, 0)
         linalg.reduce(_add, arr, init=reduce_res, dims=[1])
 
         sm = mx  # Reuse buffer
@@ -365,14 +365,14 @@ def test_softmax():
     def softmax_tensor(
         arr: Tensor[F64, N, M], reduce_res: Tensor[F64, N]
     ) -> Tensor[F64, N, M]:
-        reduce_res = linalg.fill(neg_inf, reduce_res)
+        reduce_res = linalg.fill(reduce_res, neg_inf)
         reduce_res = linalg.reduce(arith.max, arr, init=reduce_res, dims=[1])
         mx = linalg.broadcast(reduce_res, out=arr, dims=[1])
 
         arr = linalg.sub(arr, mx, out=arr)
         arr = linalg.exp(arr)
 
-        reduce_res = linalg.fill(0, reduce_res)
+        reduce_res = linalg.fill(reduce_res, 0)
         reduce_res = linalg.reduce(_add, arr, init=reduce_res, dims=[1])
         sm = linalg.broadcast(reduce_res, out=arr, dims=[1])
 

--- a/tests/e2e/test_linalg.py
+++ b/tests/e2e/test_linalg.py
@@ -292,11 +292,11 @@ def test_elemwise_bin_wrong_shape():
 def test_linalg_fill():
     @compile()
     def fill_tensor(x: F32, t1: Tensor[F64, 10, 20]) -> Tensor[F64, 10, 20]:
-        return linalg.fill(x, t1)
+        return linalg.fill(t1, x)
 
     @compile()
     def fill_memref(x: SInt32, m1: MemRef[SInt32, 100]) -> MemRef[SInt32, 100]:
-        return linalg.fill(x, m1)
+        return linalg.fill(m1, x)
 
     # Check return value for tensor
     n1 = multi_arange((10, 20), np.float64)

--- a/tests/e2e/test_linalg.py
+++ b/tests/e2e/test_linalg.py
@@ -385,7 +385,7 @@ def test_reduce_non_commutative():
 
     @compile()
     def f(arr: MemRef[UInt8, 4, 4]) -> UInt64:
-        out = alloca(MemRef[UInt64])
+        out = alloca((), UInt64)
         linalg.reduce(combine, arr, init=out, dims=[0, 1])
         return out[()]
 

--- a/tests/e2e/test_tensor.py
+++ b/tests/e2e/test_tensor.py
@@ -6,6 +6,7 @@ import weakref
 from pydsl.frontend import compile
 import pydsl.linalg as linalg
 from pydsl.memref import DYNAMIC
+import pydsl.tensor as tensor
 from pydsl.tensor import Tensor, TensorFactory
 from pydsl.type import F32, F64, Index, SInt32, Tuple, UInt64
 from helper import failed_from, compilation_failed_from, multi_arange, run
@@ -301,6 +302,52 @@ def test_zero_d():
     assert res2.shape == ()
 
 
+def test_empty():
+    @compile()
+    def f(ysz: Index) -> Tensor[SInt32, 10, DYNAMIC]:
+        t1 = tensor.empty((10, ysz), SInt32)
+        t1[1, 2] = 100
+        t1[3, 6] = 101
+        t1[9, 7] = 102
+        return t1
+
+    res = f(8)
+    assert res[1, 2] == 100
+    assert res[3, 6] == 101
+    assert res[9, 7] == 102
+
+
+def test_full():
+    @compile()
+    def f(xsz: Index) -> Tensor[UInt64, DYNAMIC, 5]:
+        t1 = tensor.full((xsz, 5), 123, UInt64)
+        return t1
+
+    test_res = f(3)
+    cor_res = np.full((3, 5), 123, dtype=np.uint64)
+    assert (test_res == cor_res).all()
+
+
+def test_zeros():
+    @compile()
+    def f() -> Tensor[F32, 10, 10]:
+        return tensor.zeros((10, 10), dtype=F32)
+
+    test_res = f()
+    cor_res = np.zeros((10, 10), dtype=np.float32)
+    assert (test_res == cor_res).all()
+
+
+def test_ones():
+    @compile()
+    def f() -> Tensor[F64, DYNAMIC, DYNAMIC]:
+        return tensor.ones((Index(6), Index(4)), dtype=F64)
+
+    test_res = f()
+    cor_res = np.ones((6, 4), dtype=np.float32)
+    assert (test_res == cor_res).all()
+
+
 if __name__ == "__main__":
     run(test_wrong_dim)
     run(test_load)
@@ -321,3 +368,7 @@ if __name__ == "__main__":
     run(test_arg_copy)
     run(test_link_ndarray)
     run(test_zero_d)
+    run(test_empty)
+    run(test_full)
+    run(test_zeros)
+    run(test_ones)

--- a/tests/unit/test_protocols.py
+++ b/tests/unit/test_protocols.py
@@ -1,0 +1,43 @@
+from functools import cache
+
+from pydsl.protocols import canonicalize_args
+
+from helper import failed_from, run
+
+
+def test_canonicalize_args():
+    calls = []
+
+    @canonicalize_args
+    @cache
+    def f(a, /, b, c=2, *, d=3):
+        calls.append((a, b, c, d))
+        return a, b, c, d
+
+    f(0, 1, 2, d=3)
+    f(0, b=1, c=2, d=3)
+    f(0, b=1, c=2)
+    f(0, b=1)
+    f(0, 1)
+    f(0, c=2, d=3, b=1)
+    f(0, d=3, b=1)
+
+    f(0, 1, d=9)
+    f(0, b=1, d=9, c=2)
+
+    assert calls == [(0, 1, 2, 3), (0, 1, 2, 9)]
+
+    # Make sure it actually returns something
+    assert f(0, 1, 2) == (0, 1, 2, 3)
+
+    with failed_from(TypeError):
+        # a is pos only
+        f(a=0, b=1, c=2, d=3)
+
+    with failed_from(TypeError):
+        # d is kw only
+        f(0, 1, 2, 3)
+
+
+if __name__ == "__main__":
+    run(test_canonicalize_args)


### PR DESCRIPTION
Added 4 new tensor functions: `empty`, `full`, `zeros`, `ones`.

Reworked syntax of `alloc` to be the same as `tensor.empty`.

Added support for memory spaces. Although they don't do too much right now, since we don't have any ops for operating on  memrefs not in the default address space. Useful for downstream `AscendTarget`.

Uses https://github.com/Huawei-CPLLab/PyDSL/pull/72 so the diff only makes sense after that is merged (can look at all but the first commit for now).

Closes #61, closes #53, closes #4.