### PR TITLE
Stop compilation if command fails

### DIFF
--- a/src/pydsl/frontend.py
+++ b/src/pydsl/frontend.py
@@ -477,18 +477,15 @@ class CTarget(CompilationTarget):
     def log_command_result(self, cmds, result) -> None:
         if result.stderr:
             warning(
-                f"""The following error is caused by this command:
-
+                f"""The following warning/error is caused by this command:
 {self.cmds_to_str(cmds)}
-
-Depending on the severity of the message,
-compilation may fail entirely.
 {"*" * 20}
-{result.stderr.decode("utf-8")}{"*" * 20}"""
+{result.stderr.decode("utf-8")}{"*" * 20}
+"""
             )
         else:
             info(
-                f"""The following command was ran without issue
+                f"""The following command ran without issues:
 {self.cmds_to_str(cmds)}
 """
             )
@@ -496,12 +493,12 @@ compilation may fail entirely.
     def run_and_get_output(self, cmds):
         result = subprocess.run(
             self.cmds_to_str(cmds),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             shell=True,
             check=False,
         )
         self.log_command_result(cmds, result)
+        result.check_returncode()
         return result.stdout.decode("utf-8") if result.stdout else None
 
     def run_and_pipe_output(self, cmds, stdout: IO):
@@ -513,6 +510,7 @@ compilation may fail entirely.
             check=False,
         )
         self.log_command_result(cmds, result)
+        result.check_returncode()
         return result.stdout.decode("utf-8") if result.stdout else None
 
     def check_cmd(self, cmd: str) -> None:


### PR DESCRIPTION
Fixes https://github.com/Huawei-CPLLab/PyDSL/issues/23.

Old error example:
```
TEST: test_load_implicit_index_uint32
WARNING:root:The following error is caused by this command:

mlir-translate --mlir-to-llvmir /tmp/pydsl_bin_roep1aah/tmpgzwg5m0j.mlir -o /tmp/pydsl_bin_roep1aah/tmpa_8bnkv4.ll

Depending on the severity of the message,
compilation may fail entirely.
********************
/tmp/pydsl_bin_roep1aah/tmpgzwg5m0j.mlir:22:5: error: Dialect `memref' not found for custom op 'memref.store' 
    memref.store %16, %15[%18] : memref<2xi32>
    ^
/tmp/pydsl_bin_roep1aah/tmpgzwg5m0j.mlir:22:5: note: Registered dialects: acc, amx, arm_neon, arm_sme, arm_sve, builtin, dlti, func, gpu, llvm, nvvm, omp, rocdl, spirv, vcix, x86vector ; for more info on dialect registration see https://mlir.llvm.org/getting_started/Faq/#registered-loaded-dependent-whats-up-with-dialects-management
********************
WARNING:root:The following error is caused by this command:

clang -O3 -shared -Wno-override-module /tmp/pydsl_bin_roep1aah/tmpa_8bnkv4.ll -o /tmp/pydsl_bin_roep1aah/tmpy15gr5rt.so -L$PYDSL_LLVM/lib -Wl,-rpath=$PYDSL_LLVM/lib -lmlir_c_runner_utils

Depending on the severity of the message,
compilation may fail entirely.
********************
clang: error: no such file or directory: '/tmp/pydsl_bin_roep1aah/tmpa_8bnkv4.ll'
********************
Traceback (most recent call last):
  File "/home/balint/PyDSL/tests/e2e/test_memref.py", line 453, in <module>
    run(test_load_implicit_index_uint32)
  File "/home/balint/PyDSL/tests/helper.py", line 67, in run
    f()
  File "/home/balint/PyDSL/tests/e2e/test_memref.py", line 28, in test_load_implicit_index_uint32
    f(n2, n2x2)
  File "/home/balint/PyDSL/src/pydsl/frontend.py", line 1325, in __call__
    return self._target.call_function(self._o.__name__, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/balint/PyDSL/src/pydsl/frontend.py", line 776, in call_function
    so_f = self.load_function(f)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/balint/PyDSL/src/pydsl/frontend.py", line 615, in load_function
    loaded_so = cdll.LoadLibrary(self._so.name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ctypes/__init__.py", line 460, in LoadLibrary
    return self._dlltype(name)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ctypes/__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: /tmp/pydsl_bin_roep1aah/tmpy15gr5rt.so: file too short
```

New error example:
```
TEST: test_load_implicit_index_uint32
WARNING:root:The following warning/error is caused by this command:
mlir-translate --mlir-to-llvmir /tmp/pydsl_bin_cec12yfd/tmp8p1sz_rq.mlir -o /tmp/pydsl_bin_cec12yfd/tmp0dk_jseh.ll
********************
/tmp/pydsl_bin_cec12yfd/tmp8p1sz_rq.mlir:22:5: error: Dialect `memref' not found for custom op 'memref.store' 
    memref.store %16, %15[%18] : memref<2xi32>
    ^
/tmp/pydsl_bin_cec12yfd/tmp8p1sz_rq.mlir:22:5: note: Registered dialects: acc, amx, arm_neon, arm_sme, arm_sve, builtin, dlti, func, gpu, llvm, nvvm, omp, rocdl, spirv, vcix, x86vector ; for more info on dialect registration see https://mlir.llvm.org/getting_started/Faq/#registered-loaded-dependent-whats-up-with-dialects-management
********************

Traceback (most recent call last):
  File "/home/balint/PyDSL/tests/e2e/test_memref.py", line 453, in <module>
    run(test_load_implicit_index_uint32)
  File "/home/balint/PyDSL/tests/helper.py", line 67, in run
    f()
  File "/home/balint/PyDSL/tests/e2e/test_memref.py", line 21, in test_load_implicit_index_uint32
    @compile(globals())
     ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/functools.py", line 909, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/balint/PyDSL/src/pydsl/frontend.py", line 1499, in _
    cf = CompiledFunction(
         ^^^^^^^^^^^^^^^^^
  File "/home/balint/PyDSL/src/pydsl/frontend.py", line 1293, in __init__
    self._target = self._settings.target_class(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/balint/PyDSL/src/pydsl/frontend.py", line 363, in __init__
    self.build()
  File "/home/balint/PyDSL/src/pydsl/frontend.py", line 756, in build
    self._so = compose([
               ^^^^^^^^^
  File "/home/balint/PyDSL/src/pydsl/frontend.py", line 45, in payload
    y = f(y)
        ^^^^
  File "/home/balint/PyDSL/src/pydsl/frontend.py", line 540, in mlir_to_ll
    self.run_and_get_output([
  File "/home/balint/PyDSL/src/pydsl/frontend.py", line 501, in run_and_get_output
    result.check_returncode()
  File "/usr/lib/python3.12/subprocess.py", line 502, in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
subprocess.CalledProcessError: Command 'mlir-translate --mlir-to-llvmir /tmp/pydsl_bin_cec12yfd/tmp8p1sz_rq.mlir -o /tmp/pydsl_bin_cec12yfd/tmp0dk_jseh.ll' returned non-zero exit status 1.
```
