### PR TITLE
Implement tensor and memref casting

### DIFF
--- a/src/pydsl/compiler.py
+++ b/src/pydsl/compiler.py
@@ -28,6 +28,7 @@ from pydsl.func import Function, TransformSequence
 # E.g. CalMacro implements the CompileTimeCallable protocol.
 # E.g. Addition in Int and Float uses the op_add magic function.
 from pydsl.protocols import (
+    canonicalize_args,
     CompileTimeClassSliceable,
     CompileTimeIterable,
     CompileTimeSliceable,
@@ -912,6 +913,7 @@ class Dialect:
     # despite being initialized twice.
     # Whereas not doing caching would result in False as they would be
     # two different objects both with name == "arith".
+    @canonicalize_args
     @cache
     def __new__(cls, *args, **kwargs):
         return super(Dialect, cls).__new__(cls)

--- a/src/pydsl/func.py
+++ b/src/pydsl/func.py
@@ -21,6 +21,7 @@ from pydsl.protocols import (
     Lowerable,
     SubtreeOut,
     ToMLIRBase,
+    canonicalize_args,
     lower,
     lower_flatten,
 )
@@ -158,6 +159,7 @@ class FunctionLike(typing.Generic[ArgsT, RetT], ABC):
         return f
 
     @classmethod
+    @canonicalize_args
     @cache
     def node_to_header(
         cls, visitor: ToMLIRBase, node: ast.FunctionDef
@@ -196,6 +198,7 @@ class FunctionLike(typing.Generic[ArgsT, RetT], ABC):
         return cls.class_factory(args, ret)
 
     @classmethod
+    @canonicalize_args
     @cache
     def class_factory(
         cls,

--- a/src/pydsl/gpu.py
+++ b/src/pydsl/gpu.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+from mlir.ir import AttrBuilder
+import mlir.dialects.gpu as gpu
+
+from pydsl.memref import MemorySpace
+
+
+class GPU_AddrSpace(MemorySpace, Enum):
+    Global = gpu.AddressSpace.Global
+    Workgroup = gpu.AddressSpace.Workgroup
+    Private = gpu.AddressSpace.Private
+
+    def lower(self):
+        return (
+            AttrBuilder.get("GPU_AddressSpaceAttr")(self.value, context=None),
+        )

--- a/src/pydsl/linalg.py
+++ b/src/pydsl/linalg.py
@@ -304,7 +304,7 @@ def batch_matmul(visitor: "ToMLIRBase", x: Compiled, y: Compiled):
 
 
 @CallMacro.generate()
-def fill(visitor: "ToMLIRBase", c: Compiled, x: Compiled) -> Tensor | MemRef:
+def fill(visitor: "ToMLIRBase", x: Compiled, c: Compiled) -> Tensor | MemRef:
     """
     Fill a MemRef/Tensor with the single value c.
     If x is a MemRef, it is modified in-place.

--- a/src/pydsl/memref.py
+++ b/src/pydsl/memref.py
@@ -20,7 +20,13 @@ from mlir.ir import (
 
 from pydsl.affine import AffineContext, AffineMapExpr, AffineMapExprWalk
 from pydsl.macro import CallMacro, Compiled, Evaluated
-from pydsl.protocols import ArgContainer, SubtreeOut, ToMLIRBase, lower
+from pydsl.protocols import (
+    ArgContainer,
+    canonicalize_args,
+    SubtreeOut,
+    ToMLIRBase,
+    lower,
+)
 from pydsl.type import (
     Index,
     Lowerable,
@@ -384,6 +390,7 @@ class MemRef(typing.Generic[DType, *Shape], UsesRMRD):
     ]
 
     @staticmethod
+    @canonicalize_args
     @cache
     def class_factory(
         shape: tuple[int],

--- a/src/pydsl/memref.py
+++ b/src/pydsl/memref.py
@@ -21,7 +21,7 @@ from mlir.ir import (
 )
 
 from pydsl.affine import AffineContext, AffineMapExpr, AffineMapExprWalk
-from pydsl.macro import CallMacro, Compiled, Evaluated
+from pydsl.macro import CallMacro, Compiled, Evaluated, MethodType
 from pydsl.protocols import (
     ArgContainer,
     canonicalize_args,
@@ -179,6 +179,18 @@ def are_shapes_compatible(arr1: Iterable[int], arr2: Iterable[int]) -> bool:
     return len(arr1) == len(arr2) and all(
         a == b or a == DYNAMIC or b == DYNAMIC for a, b in zip(arr1, arr2)
     )
+
+
+def assert_shapes_compatible(arr1: Iterable[int], arr2: Iterable[int]) -> None:
+    """
+    Checks that non-dynamic dimensions of arr1 and arr2 match, throws a
+    ValueError if not.
+    """
+    if not are_shapes_compatible(arr1, arr2):
+        raise ValueError(
+            f"incompatible shapes: {repr(arr1)} and {repr(arr2)}, non-dynamic "
+            f"dimensions must be equal"
+        )
 
 
 class UsesRMRD:
@@ -657,6 +669,86 @@ class MemRef(typing.Generic[DType, *Shape], UsesRMRD):
 
         # Equivalent to cls.__class_getitem__(args)
         return cls[args]
+
+    @CallMacro.generate(method_type=MethodType.INSTANCE)
+    def cast(
+        visitor: ToMLIRBase,
+        self: typing.Self,
+        shape: Evaluated = None,
+        *,
+        offset: Evaluated = None,
+        strides: Evaluated = (-1,),
+    ) -> typing.Self:
+        """
+        Converts a memref from one type to an equivalent type with a compatible
+        shape. The source and destination types are compatible if all of the
+        following are true:
+        - Both are ranked memref types with the same element type, address
+        space, and rank.
+        - Both have the same layout or both have compatible strided layouts.
+        - The individual sizes (resp. offset and strides in the case of strided
+        memrefs) may convert constant dimensions to dynamic dimensions and
+        vice-versa.
+
+        If the cast converts any dimensions from an unknown to a known size,
+        then it acts as an assertion that fails at runtime if the dynamic
+        dimensions disagree with the resultant destination size (i.e. it is
+        illegal to do a conversion that causes a mismatch, and it would invoke
+        undefined behaviour).
+
+        Note: a new memref with the new type is returned, the type of the
+        original memref is not modified.
+
+        Example:
+        ```
+        def f(m1: MemRef[F32, DYNAMIC, 32, 5]) -> MemRef[F32, 64, 32, DYNAMIC]:
+            # Only valid if the first dimension of m1 is always 64
+            m2 = m1.cast((64, 32, DYNAMIC))
+            return m2
+        ```
+        """
+        # NOTE: default value of strides is (-1,) because None is already used
+        # to represent default layout... This is definitely not a great
+        # solution, but it's unclear how to do this better.
+
+        shape = tuple(shape) if shape is not None else self.shape
+        offset = int(offset) if offset is not None else self.offset
+        strides = (
+            None
+            if strides is None
+            else self.strides
+            if strides == (-1,)
+            else tuple(strides)
+        )
+
+        if not all(isinstance(x, int) for x in shape):
+            raise ValueError(
+                f"shape should be a tuple of integers known at compile time ",
+                f"got {repr(shape)}",
+            )
+
+        if not (strides is None or all(isinstance(x, int) for x in strides)):
+            raise ValueError(
+                f"strides should be a tuple of integers known at compile ",
+                f"time, got {repr(strides)}",
+            )
+
+        assert_shapes_compatible(self.shape, shape)
+        assert_shapes_compatible([self.offset], [offset])
+
+        # TODO: also do a type check if one of the MemRefs is default layout.
+        # This is a reasonably complicated check, and even MLIR doesn't do it
+        # properly. E.g. mlir-opt allows
+        # `memref<3x4xf64, strided<[8, 1], offset: ?>> to memref<?x?xf64>`
+        # to compile, even though it is impossible for this to be correct.
+        if self.strides is not None and strides is not None:
+            assert_shapes_compatible(self.strides, strides)
+
+        result_type = self.class_factory(
+            shape, self.element_type, offset=offset, strides=strides
+        )
+        rep = memref.cast(lower_single(result_type), lower_single(self))
+        return result_type(rep)
 
     def lower(self) -> tuple[Value]:
         return (self.value,)

--- a/src/pydsl/tensor.py
+++ b/src/pydsl/tensor.py
@@ -23,7 +23,7 @@ from pydsl.type import (
     SupportsIndex,
     Tuple,
 )
-from pydsl.protocols import SubtreeOut, ToMLIRBase
+from pydsl.protocols import canonicalize_args, SubtreeOut, ToMLIRBase
 
 DYNAMIC = -9223372036854775808
 
@@ -57,6 +57,7 @@ class Tensor(typing.Generic[DType, *Shape], UsesRMRD):
     ]
 
     @staticmethod
+    @canonicalize_args
     @cache
     def class_factory(
         shape: tuple[int], element_type, *, name=_default_subclass_name

--- a/src/pydsl/tensor.py
+++ b/src/pydsl/tensor.py
@@ -1,5 +1,5 @@
 import ast
-import collections.abc as cabc
+from collections.abc import Iterable
 from functools import cache
 import typing
 
@@ -7,23 +7,24 @@ from mlir.dialects import tensor
 import mlir.ir as mlir
 from mlir.ir import DenseI64ArrayAttr, OpView, RankedTensorType, Value
 
+from pydsl.func import InlineFunction
 from pydsl.macro import CallMacro, Compiled, Evaluated
 from pydsl.memref import (
     UsesRMRD,
     RuntimeMemrefShape,
     slices_to_mlir_format,
+    split_static_dynamic_dims,
     subtree_to_slices,
 )
+from pydsl.protocols import canonicalize_args, SubtreeOut, ToMLIRBase
 from pydsl.type import (
     Index,
     Lowerable,
-    lower,
     lower_flatten,
     lower_single,
     SupportsIndex,
     Tuple,
 )
-from pydsl.protocols import canonicalize_args, SubtreeOut, ToMLIRBase
 
 DYNAMIC = -9223372036854775808
 
@@ -42,10 +43,11 @@ class Tensor(typing.Generic[DType, *Shape], UsesRMRD):
     """
 
     value: Value
-    shape: tuple[int] = None
-    element_type: Lowerable = None
-    offset: int = None
-    strides: tuple[int] = None
+    shape: tuple[int]
+    element_type: Lowerable
+    offset: int
+    strides: tuple[int] | None
+
     _default_subclass_name = "AnnonymousTensorSubclass"
     _supported_mlir_type = [
         mlir.IntegerType,
@@ -60,7 +62,7 @@ class Tensor(typing.Generic[DType, *Shape], UsesRMRD):
     @canonicalize_args
     @cache
     def class_factory(
-        shape: tuple[int], element_type, *, name=_default_subclass_name
+        shape: Iterable[int], element_type, *, name=_default_subclass_name
     ):
         """
         Create a new subclass of Tensor dynamically with the specified
@@ -72,7 +74,7 @@ class Tensor(typing.Generic[DType, *Shape], UsesRMRD):
         # store composite types, got {element_type} which lowers to
         # {lower(element_type)}")
 
-        if not isinstance(shape, cabc.Iterable):
+        if not isinstance(shape, Iterable):
             raise TypeError(
                 f"Tensor requires shape to be iterable, got {type(shape)}"
             )
@@ -278,45 +280,37 @@ class Tensor(typing.Generic[DType, *Shape], UsesRMRD):
 TensorFactory = Tensor.class_factory
 
 
-def verify_tensor_type(t_type: type[Tensor]):
-    if not issubclass(t_type, Tensor):
-        raise TypeError(
-            f"the type being allocated must be a subclass of Tensor, got "
-            f"{t_type}"
-        )
-
-
-def verify_dynamics_val(t_type: type[Tensor], dynamics_val: Tuple) -> None:
-    dynamics_val = lower(dynamics_val)
-
-    if not isinstance(dynamics_val, cabc.Iterable):
-        raise TypeError(f"{repr(dynamics_val)} is not iterable")
-
-    if (actual_dyn := len(dynamics_val)) != (
-        target_dyn := t_type.shape.count(DYNAMIC)
-    ):
-        raise ValueError(
-            f"Tensor has {target_dyn} dynamic dimensions to be filled, "
-            f"but emptyOp received {actual_dyn}"
-        )
-
-
 @CallMacro.generate()
 def empty(
-    visitor: ToMLIRBase, t_type: Evaluated, dynamics_val: Compiled = None
+    visitor: ToMLIRBase, shape: Compiled, dtype: Evaluated
 ) -> SubtreeOut:
-    if dynamics_val is None:
-        dynamics_val = Tuple.from_values(visitor, *())
-    verify_tensor_type(t_type)
-    verify_dynamics_val(t_type, dynamics_val)
-    dynamics_val = [lower_single(Index(i)) for i in lower(dynamics_val)]
-    idx = 0
-    orig_shape = t_type.shape
-    shape = [0] * len(orig_shape)
-    for i in range(len(orig_shape)):
-        if orig_shape[i] == DYNAMIC:
-            shape[i] = dynamics_val[idx]
-            idx += 1
-        else:
-            shape[i] = orig_shape[i]
-    return t_type(tensor.empty(shape, lower_single(t_type.element_type)))
+    if not isinstance(shape, Tuple):
+        raise TypeError(f"shape should be a Tuple, got {type(shape)}")
+
+    shape = shape.as_iterable(visitor)
+    static_shape, dynamic_sizes = split_static_dynamic_dims(shape)
+
+    t_type = TensorFactory(tuple(static_shape), dtype)
+    return t_type(
+        tensor.empty(lower_single(t_type), lower_flatten(dynamic_sizes))
+    )
+
+
+# This is not at the top of the file to avoid circular import
+import pydsl.linalg as linalg
+
+
+@InlineFunction.generate()
+def full(shape, val, dtype) -> typing.Any:
+    res = empty(shape, dtype)
+    return linalg.fill(res, val)
+
+
+@InlineFunction.generate()
+def zeros(shape, dtype) -> typing.Any:
+    return full(shape, 0, dtype)
+
+
+@InlineFunction.generate()
+def ones(shape, dtype) -> typing.Any:
+    return full(shape, 1, dtype)

--- a/src/pydsl/type.py
+++ b/src/pydsl/type.py
@@ -31,7 +31,8 @@ from mlir.ir import (
 )
 
 from pydsl.macro import CallMacro, MethodType, Uncompiled
-from pydsl.protocols import ToMLIRBase, ArgContainer
+from pydsl.protocols import ArgContainer, canonicalize_args, ToMLIRBase
+from pydsl.protocols import ArgContainer, canonicalize_args, ToMLIRBase
 
 if TYPE_CHECKING:
     # This is for imports for type hinting purposes only and which can result
@@ -1214,6 +1215,7 @@ class Tuple(typing.Generic[*DTypes]):
     value: tuple
 
     @staticmethod
+    @canonicalize_args
     @cache
     def class_factory(
         dtypes: tuple[type], name=_default_subclass_name

--- a/src/pydsl/vector.py
+++ b/src/pydsl/vector.py
@@ -6,7 +6,12 @@ import mlir.ir as mlir
 from mlir.ir import OpView, Value, VectorType
 
 from pydsl.type import Lowerable
-from pydsl.protocols import lower_single, SubtreeOut, ToMLIRBase
+from pydsl.protocols import (
+    canonicalize_args,
+    lower_single,
+    SubtreeOut,
+    ToMLIRBase,
+)
 
 
 class Vector:
@@ -32,6 +37,7 @@ class Vector:
     ]
 
     @staticmethod
+    @canonicalize_args
     @cache
     def class_factory(
         shape: tuple[int], element_type, *, name=_default_subclass_name

--- a/tests/e2e/test_algorithms.py
+++ b/tests/e2e/test_algorithms.py
@@ -341,7 +341,7 @@ def test_softmax():
     @compile()
     def softmax_memref(arr: MemRef[F64, N, M]) -> MemRef[F64, N, M]:
         reduce_res = alloca(MemRef[F64, N])
-        linalg.fill(neg_inf, reduce_res)
+        linalg.fill(reduce_res, neg_inf)
         linalg.reduce(arith.max, arr, init=reduce_res, dims=[1])
 
         mx = alloca(MemRef[F64, N, M])
@@ -350,7 +350,7 @@ def test_softmax():
 
         linalg.exp(arr)
 
-        linalg.fill(0, reduce_res)
+        linalg.fill(reduce_res, 0)
         linalg.reduce(_add, arr, init=reduce_res, dims=[1])
 
         sm = mx  # Reuse buffer
@@ -365,14 +365,14 @@ def test_softmax():
     def softmax_tensor(
         arr: Tensor[F64, N, M], reduce_res: Tensor[F64, N]
     ) -> Tensor[F64, N, M]:
-        reduce_res = linalg.fill(neg_inf, reduce_res)
+        reduce_res = linalg.fill(reduce_res, neg_inf)
         reduce_res = linalg.reduce(arith.max, arr, init=reduce_res, dims=[1])
         mx = linalg.broadcast(reduce_res, out=arr, dims=[1])
 
         arr = linalg.sub(arr, mx, out=arr)
         arr = linalg.exp(arr)
 
-        reduce_res = linalg.fill(0, reduce_res)
+        reduce_res = linalg.fill(reduce_res, 0)
         reduce_res = linalg.reduce(_add, arr, init=reduce_res, dims=[1])
         sm = linalg.broadcast(reduce_res, out=arr, dims=[1])
 

--- a/tests/e2e/test_linalg.py
+++ b/tests/e2e/test_linalg.py
@@ -292,11 +292,11 @@ def test_elemwise_bin_wrong_shape():
 def test_linalg_fill():
     @compile()
     def fill_tensor(x: F32, t1: Tensor[F64, 10, 20]) -> Tensor[F64, 10, 20]:
-        return linalg.fill(x, t1)
+        return linalg.fill(t1, x)
 
     @compile()
     def fill_memref(x: SInt32, m1: MemRef[SInt32, 100]) -> MemRef[SInt32, 100]:
-        return linalg.fill(x, m1)
+        return linalg.fill(m1, x)
 
     # Check return value for tensor
     n1 = multi_arange((10, 20), np.float64)

--- a/tests/e2e/test_linalg.py
+++ b/tests/e2e/test_linalg.py
@@ -385,7 +385,7 @@ def test_reduce_non_commutative():
 
     @compile()
     def f(arr: MemRef[UInt8, 4, 4]) -> UInt64:
-        out = alloca(MemRef[UInt64])
+        out = alloca((), UInt64)
         linalg.reduce(combine, arr, init=out, dims=[0, 1])
         return out[()]
 

--- a/tests/e2e/test_memref.py
+++ b/tests/e2e/test_memref.py
@@ -434,6 +434,60 @@ def test_zero_d():
     assert res2.shape == ()
 
 
+def test_cast_basic():
+    @compile()
+    def f(
+        m1: MemRef[F32, 10, DYNAMIC, 30],
+    ) -> MemRef[F32, DYNAMIC, 20, DYNAMIC]:
+        m1 = m1.cast((DYNAMIC, 20, 30), strides=(600, 30, 1))
+        m1 = m1.cast((DYNAMIC, DYNAMIC, DYNAMIC))
+        m1 = m1.cast((10, 20, 30), strides=None)
+        m1 = m1.cast((DYNAMIC, 20, DYNAMIC))
+        return m1
+
+    n1 = multi_arange((10, 20, 30), dtype=np.float32)
+    cor_res = n1.copy()
+    assert (f(n1) == cor_res).all()
+
+
+def test_cast_strided():
+    MemRef1 = MemRef.get((8, DYNAMIC), SInt16, offset=10, strides=(1, 8))
+    MemRef2 = MemRef.get((8, 4), SInt16, offset=DYNAMIC, strides=(DYNAMIC, 8))
+
+    @compile()
+    def f(m1: MemRef1) -> MemRef2:
+        m1.cast(strides=(1, DYNAMIC))
+        m1 = m1.cast((8, 4), offset=DYNAMIC, strides=(DYNAMIC, 8))
+        return m1
+
+    i16_sz = np.int16().nbytes
+    n1 = multi_arange((8, 4), np.int16)
+    n1 = as_strided(n1, shape=(8, 4), strides=(i16_sz, 8 * i16_sz))
+    cor_res = n1.copy()
+    assert (f(n1) == cor_res).all()
+
+
+def test_cast_bad():
+    with compilation_failed_from(ValueError):
+
+        @compile()
+        def f1(m1: MemRef[UInt32, 5, 8]):
+            m1.cast((5, 8, 7))
+
+    with compilation_failed_from(ValueError):
+
+        @compile()
+        def f2(m1: MemRef[F64, DYNAMIC, 4]):
+            m1.cast((DYNAMIC, 5))
+
+    with compilation_failed_from(ValueError):
+        MemRef1 = MemRef.get((8, DYNAMIC), F32, offset=10, strides=(1, 8))
+
+        @compile()
+        def f3(m1: MemRef1):
+            m1.cast(strides=(DYNAMIC, 16))
+
+
 if __name__ == "__main__":
     run(test_load_implicit_index_uint32)
     run(test_load_implicit_index_f64)
@@ -457,3 +511,6 @@ if __name__ == "__main__":
     run(test_link_ndarray)
     run(test_chain_link_ndarray)
     run(test_zero_d)
+    run(test_cast_basic)
+    run(test_cast_strided)
+    run(test_cast_strided)

--- a/tests/e2e/test_memref.py
+++ b/tests/e2e/test_memref.py
@@ -6,8 +6,9 @@ import weakref
 
 from pydsl.affine import affine_range as arange
 from pydsl.frontend import compile
+from pydsl.gpu import GPU_AddrSpace
 import pydsl.linalg as linalg
-from pydsl.memref import alloc, alloca, DYNAMIC, Dynamic, MemRef, MemRefFactory
+from pydsl.memref import alloc, alloca, dealloc, DYNAMIC, MemRef, MemRefFactory
 from pydsl.type import Bool, F32, F64, Index, SInt16, Tuple, UInt32
 from helper import compilation_failed_from, failed_from, multi_arange, run
 
@@ -100,7 +101,7 @@ def test_return_tuple_memref():
 def test_alloca_scalar():
     @compile()
     def f() -> UInt32:
-        m_scalar = alloca(MemRef[UInt32, 1])
+        m_scalar = alloca((1,), UInt32)
 
         for i in arange(10):
             m_scalar[0] = i
@@ -113,7 +114,7 @@ def test_alloca_scalar():
 def test_alloca_dynamic():
     @compile()
     def f(a: Index, b: Index) -> Tuple[UInt32, UInt32]:
-        m = alloca(MemRef[UInt32, Dynamic, 2, Dynamic], (a, b))
+        m = alloca((a, 2, b), UInt32)
 
         m[0, 0, 0] = 1
         m[a - 1, 1, b - 1] = 2
@@ -127,62 +128,46 @@ def test_alloca_dynamic():
 def test_alloc_scalar():
     @compile()
     def f() -> MemRef[UInt32, 1]:
-        m_scalar = alloc(MemRef[UInt32, 1])
+        m_scalar = alloc((1,), UInt32)
         m_scalar[0] = 1
         return m_scalar
 
     assert (f() == np.asarray([1], dtype=np.uint32)).all()
 
 
-def test_alloc_wrong_dynamic_sizes():
-    with compilation_failed_from(ValueError):
-        # 2 dynamic dimensions, 1 specified
-        @compile()
-        def f1(a: Index):
-            m1 = alloc(MemRef[F32, 4, 5, DYNAMIC, DYNAMIC], (a,))
+def test_dealloc():
+    """
+    Doesn't really test whether the memref is deallocated, since that's hard
+    to test, but does test that the syntax of dealloc works.
+    """
 
-    with compilation_failed_from(ValueError):
-        # 1 dynamic dimension, 3 specified
-        @compile()
-        def f2(a: Index, b: Index, c: Index):
-            m1 = alloc(MemRef[UInt32, DYNAMIC, 8], (a, b, c))
+    @compile()
+    def f() -> SInt16:
+        m = alloc((3, Index(7)), SInt16)
+        m[1, 2] = 5
+        res = m[1, 2]
+        dealloc(m)
+        return res
 
-    with compilation_failed_from(ValueError):
-        # 0 dynamic dimensins, 2 specified
-        @compile()
-        def f3(a: Index, b: Index):
-            m1 = alloc(MemRef[SInt16, 4, 4], (a, b))
+    assert f() == 5
 
-    with compilation_failed_from(ValueError):
-        # 1 dynamic dimension, 0 specified
-        @compile()
-        def f4():
-            m1 = alloc(MemRef[F64, DYNAMIC])
+    mlir = f.emit_mlir()
+    assert r"memref.dealloc" in mlir
 
 
-def test_alloca_strided():
-    # TODO: currently, it seems we cannot lower alloc/alloca
-    # calls that use memrefs of non-trivial layouts from MLIR -> LLVMIR.
-    # The code for generating the MLIR from Python exists (but cannot be tested).
-    # If we find the right MLIR pass for this lowering, we should make
-    # this code compile and add more tests that check alloc/alloca of
-    # strided MemRefs (e.g. dynamic strides, invalid dynamic_symbols etc.).
+def test_alloc_memory_space():
+    """
+    We can't use GPU address spaces on CPU, so just test if it compiles and
+    the MLIR is reasonable.
+    """
 
-    with compilation_failed_from(NotImplementedError):
-        MemRefStrided = MemRefFactory((2, 3), SInt16, strides=(4, 7))
+    @compile(auto_build=False)
+    def f():
+        m = alloc((4, 2), F32, memory_space=GPU_AddrSpace.Global)
+        dealloc(m)
 
-        @compile()
-        def f() -> Tuple[SInt16, SInt16, SInt16]:
-            m1 = alloca(MemRefStrided)
-            m1[0, 0] = 5
-            m1[0, 1] = 8
-            m1[0, 2] = 40
-            m1[1, 0] = 3
-            m1[1, 1] = 5
-            m1[1, 2] = -12
-            return m1[0, 1], m1[0, 2], m1[1, 2]
-
-        assert f() == (8, 40, -12)
+    mlir = f.emit_mlir()
+    assert r"memref<4x2xf32, #gpu.address_space<global>>" in mlir
 
 
 def test_load_strided():
@@ -459,8 +444,8 @@ if __name__ == "__main__":
     run(test_alloca_scalar)
     run(test_alloca_dynamic)
     run(test_alloc_scalar)
-    run(test_alloc_wrong_dynamic_sizes)
-    run(test_alloca_strided)
+    run(test_dealloc)
+    run(test_alloc_memory_space)
     run(test_load_strided)
     run(test_load_strided_big)
     run(test_load_strided_wrong)

--- a/tests/e2e/test_tensor.py
+++ b/tests/e2e/test_tensor.py
@@ -6,6 +6,7 @@ import weakref
 from pydsl.frontend import compile
 import pydsl.linalg as linalg
 from pydsl.memref import DYNAMIC
+import pydsl.tensor as tensor
 from pydsl.tensor import Tensor, TensorFactory
 from pydsl.type import F32, F64, Index, SInt32, Tuple, UInt64
 from helper import failed_from, compilation_failed_from, multi_arange, run
@@ -301,6 +302,52 @@ def test_zero_d():
     assert res2.shape == ()
 
 
+def test_empty():
+    @compile()
+    def f(ysz: Index) -> Tensor[SInt32, 10, DYNAMIC]:
+        t1 = tensor.empty((10, ysz), SInt32)
+        t1[1, 2] = 100
+        t1[3, 6] = 101
+        t1[9, 7] = 102
+        return t1
+
+    res = f(8)
+    assert res[1, 2] == 100
+    assert res[3, 6] == 101
+    assert res[9, 7] == 102
+
+
+def test_full():
+    @compile()
+    def f(xsz: Index) -> Tensor[UInt64, DYNAMIC, 5]:
+        t1 = tensor.full((xsz, 5), 123, UInt64)
+        return t1
+
+    test_res = f(3)
+    cor_res = np.full((3, 5), 123, dtype=np.uint64)
+    assert (test_res == cor_res).all()
+
+
+def test_zeros():
+    @compile()
+    def f() -> Tensor[F32, 10, 10]:
+        return tensor.zeros((10, 10), dtype=F32)
+
+    test_res = f()
+    cor_res = np.zeros((10, 10), dtype=np.float32)
+    assert (test_res == cor_res).all()
+
+
+def test_ones():
+    @compile()
+    def f() -> Tensor[F64, DYNAMIC, DYNAMIC]:
+        return tensor.ones((Index(6), Index(4)), dtype=F64)
+
+    test_res = f()
+    cor_res = np.ones((6, 4), dtype=np.float32)
+    assert (test_res == cor_res).all()
+
+
 if __name__ == "__main__":
     run(test_wrong_dim)
     run(test_load)
@@ -321,3 +368,7 @@ if __name__ == "__main__":
     run(test_arg_copy)
     run(test_link_ndarray)
     run(test_zero_d)
+    run(test_empty)
+    run(test_full)
+    run(test_zeros)
+    run(test_ones)

--- a/tests/e2e/test_tensor.py
+++ b/tests/e2e/test_tensor.py
@@ -348,6 +348,31 @@ def test_ones():
     assert (test_res == cor_res).all()
 
 
+def test_cast():
+    @compile()
+    def f(t1: Tensor[F32, DYNAMIC, 32, 5]) -> Tensor[F32, 64, 32, DYNAMIC]:
+        t2 = t1.cast((64, 32, DYNAMIC))
+        return t2
+
+    n1 = multi_arange((64, 32, 5), np.float32)
+    cor_res = n1.copy()
+    assert (f(n1) == cor_res).all()
+
+
+def test_cast_bad():
+    with compilation_failed_from(ValueError):
+
+        @compile()
+        def f1(t1: Tensor[SInt32, DYNAMIC, 13]):
+            t1.cast((7, 13, DYNAMIC))
+
+    with compilation_failed_from(ValueError):
+
+        @compile()
+        def f2(t1: Tensor[UInt64, 3, 7]):
+            t1.cast((1, 21))
+
+
 if __name__ == "__main__":
     run(test_wrong_dim)
     run(test_load)
@@ -372,3 +397,5 @@ if __name__ == "__main__":
     run(test_full)
     run(test_zeros)
     run(test_ones)
+    run(test_cast)
+    run(test_cast_bad)

--- a/tests/unit/test_protocols.py
+++ b/tests/unit/test_protocols.py
@@ -1,0 +1,43 @@
+from functools import cache
+
+from pydsl.protocols import canonicalize_args
+
+from helper import failed_from, run
+
+
+def test_canonicalize_args():
+    calls = []
+
+    @canonicalize_args
+    @cache
+    def f(a, /, b, c=2, *, d=3):
+        calls.append((a, b, c, d))
+        return a, b, c, d
+
+    f(0, 1, 2, d=3)
+    f(0, b=1, c=2, d=3)
+    f(0, b=1, c=2)
+    f(0, b=1)
+    f(0, 1)
+    f(0, c=2, d=3, b=1)
+    f(0, d=3, b=1)
+
+    f(0, 1, d=9)
+    f(0, b=1, d=9, c=2)
+
+    assert calls == [(0, 1, 2, 3), (0, 1, 2, 9)]
+
+    # Make sure it actually returns something
+    assert f(0, 1, 2) == (0, 1, 2, 3)
+
+    with failed_from(TypeError):
+        # a is pos only
+        f(a=0, b=1, c=2, d=3)
+
+    with failed_from(TypeError):
+        # d is kw only
+        f(0, 1, 2, 3)
+
+
+if __name__ == "__main__":
+    run(test_canonicalize_args)


### PR DESCRIPTION
Not sure whether the method name is ideal, maybe there is a better name for this behaviour? (Only static vs dynamic dimensions can be converted, the object is not modified in-place).

Builds on #82.