### PR TITLE
fixes #87: avoid calling visit_ twice. also fixes #93

### DIFF
--- a/tests/e2e/test_func.py
+++ b/tests/e2e/test_func.py
@@ -489,7 +489,6 @@ def test_inline_func_pos_as_kw_only():
             return inline_f(x, y)
 
 
-@pytest.mark.xfail(reason="https://github.com/Huawei-CPLLab/PyDSL/issues/93")
 def test_inline_func_scope_good():
     c = 56
 


### PR DESCRIPTION
fixes #87 #93

Removing `@cache` on `visit` causes the node after the directive gets visited twice (the first time in `handle_directive`, through `node.next_line`, then by the general logic of iterating over the body of the containing node). Hence, we need to set up a flag in `handle_directive` to skip the second visit.

The solution is not very elegant; though it can be benefited by multi-pass compilation: a pass can move the node after a directive as the sub-node of the directive.