### PR TITLE
fix #112: better syntax for decorators

### DIFF
--- a/examples/autotune/heat_demo.py
+++ b/examples/autotune/heat_demo.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from pydsl.transform import (
+    decorate_next,
     fuse,
     get_loop,
     tile,
@@ -60,9 +61,9 @@ def heat_fuse_tile(
 ):
     a: F32 = 2.0
     b: F32 = 0.125
-    """@tag("tile")"""
+    decorate_next(tag("tile"))
     for _ in arange(tsteps):
-        """@tag("fuse_1")"""
+        decorate_next(tag("fuse_1"))
         for i in arange(1, n - 1):
             for j in arange(1, n - 1):
                 for k in arange(1, n - 1):
@@ -77,7 +78,7 @@ def heat_fuse_tile(
                         - a * A[i, j, k]
                         + A[i, j, k - 1]
                     )
-        """@tag("fuse_2")"""
+        decorate_next(tag("fuse_2"))
         for i in arange(1, n - 1):
             for j in arange(1, n - 1):
                 for k in arange(1, n - 1):

--- a/examples/autotune/tune_combined.py
+++ b/examples/autotune/tune_combined.py
@@ -6,7 +6,7 @@ from pydsl.type import Index, F16, F32, F64, AnyOp
 from pydsl.memref import MemRefFactory
 from pydsl.frontend import CTarget, PolyCTarget
 from pydsl.affine import affine_range as arange
-from pydsl.transform import tile, tag, match_tag as match
+from pydsl.transform import decorate_next, tile, tag, match_tag as match
 
 from pydsl.autotune import autotune, Var, Setting, TestingData
 
@@ -38,7 +38,7 @@ autotune_values *= TestingData([[N, A]])
 def heat_fuse_tile(n: Index, A: MemF32):
     num = Index(NUM)
     for _ in arange(num):
-        """@tag("tile")"""
+        decorate_next(tag("tile"))
         for i in arange(n):
             for j in arange(n):
                 t = DATA_TYPE(A[i, j])

--- a/examples/autotune/tune_transform.py
+++ b/examples/autotune/tune_transform.py
@@ -1,6 +1,12 @@
 import numpy as np
 
-from pydsl.transform import tile, parallel, tag, match_tag as match
+from pydsl.transform import (
+    decorate_next,
+    tile,
+    parallel,
+    tag,
+    match_tag as match,
+)
 from pydsl.type import Index, AnyOp, F32
 from pydsl.memref import MemRef
 from pydsl.frontend import PolyCTarget
@@ -45,8 +51,8 @@ autotune_values *= Setting.target_class([PolyCTarget])
 @autotune(autotune_values)
 def heat_fuse_tile(n: Index, A: MemRef[F32, N, N]):
     for _ in arange(100):
-        """@tag("loop_outter")"""
+        decorate_next(tag("loop_outter"))
         for i in arange(n):
-            """@tag("loop_inner")"""
+            decorate_next(tag("loop_inner"))
             for j in arange(n):
                 A[i, j] = (-1.5) * A[i, j] * A[i, j] + (2.5) * A[i, j] + 1

--- a/examples/with_recursively.py
+++ b/examples/with_recursively.py
@@ -14,8 +14,8 @@ def with_recursively_example(
 ):
     for i in arange(40):
         for j in arange(40):
-            with recursively(lambda x: int_attr(x, "set", 1)):
+            with recursively(int_attr("set", 1)):
                 s[j] = (s[j] + r[i]) * A[i, j]
 
-            with recursively(lambda x: int_attr(x, "set", 2)):
+            with recursively(int_attr("set", 2)):
                 q[i] = (q[i] + p[i]) * A[i, j]

--- a/src/pydsl/compiler.py
+++ b/src/pydsl/compiler.py
@@ -27,6 +27,7 @@ from pydsl.func import Function, TransformSequence
 # being imported explicitly.
 # E.g. CalMacro implements the CompileTimeCallable protocol.
 # E.g. Addition in Int and Float uses the op_add magic function.
+from pydsl.macro import CallMacro
 from pydsl.protocols import (
     canonicalize_args,
     CompileTimeClassSliceable,
@@ -225,9 +226,6 @@ class CompilationError(Exception):
         return f"{locator}\n{joined_line_display}\n{error_info}"
 
 
-DIRECTIVE_ESCAPE = "@"
-
-
 class ToMLIR(ToMLIRBase):
     mlir = None
     scope_stack: ScopeStack = None
@@ -329,51 +327,8 @@ class ToMLIR(ToMLIRBase):
             self, *[self.visit(entry) for entry in node.elts]
         )
 
-    def handle_directive(self, node: ast.Expr) -> SubtreeOut:
-        val = node.value.value
-
-        if (not hasattr(node, "next_line")) or (
-            operand := node.next_line
-        ) is None:
-            raise ValueError(
-                "docstring '@' directive must be placed before a valid "
-                "operator"
-            )
-
-        directive_expr = val[len(DIRECTIVE_ESCAPE) :]
-        directive_ast = ast.parse(directive_expr).body[0]
-
-        if type(directive_ast) is not ast.Expr:
-            raise ValueError("docstring '@' directive is not an expression")
-
-        match value := directive_ast.value:
-            case ast.Call():
-                # adds the AST as the first parameter, similar to
-                # how self works in Python
-                rst = handle_CompileTimeCallable(
-                    self, value, prefix_args=(operand,)
-                )
-                self.skip_next = True
-                return rst
-
-            case _:
-                raise TypeError(
-                    f"docstring '@' directive expression immediately contains "
-                    f"{type(value)}, which is not supported"
-                )
-
     def visit_Expr(self, node: ast.Expr) -> SubtreeOut:
-        DIRECTIVE_ESCAPE = "@"
-
-        expr_val = node.value
-
-        match expr_val:
-            case ast.Constant():
-                val = expr_val.value
-                if type(val) is str and val.startswith(DIRECTIVE_ESCAPE):
-                    return self.handle_directive(node)
-            case _:
-                self.visit(expr_val)
+        return self.visit(node.value)
 
     def visit_Expression(self, node: ast.Expression) -> SubtreeOut:
         # ast.Expression is output by ast.parse(mode="eval")
@@ -669,10 +624,10 @@ class ToMLIR(ToMLIRBase):
 
         A Name will simply be evaluated to its id nested in a list.
         """
-        match node.value:
+        match node:
             case ast.Attribute(attr=attrname):  # chain length > 1
                 next_node = node.value
-                return self.get_attr_chain(next_node).insert(0, attrname)
+                return [attrname] + self.get_attr_chain(next_node)
             case ast.Name(id=id):  # chain length = 1
                 return [id]
 
@@ -832,7 +787,28 @@ class ToMLIR(ToMLIRBase):
         )
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> SubtreeOut:
-        return Function.full_init(self, node)
+        # skip @compile and @template
+        decorator_list = [
+            d
+            for d in node.decorator_list
+            if isinstance(
+                self.scope_stack.resolve_attr_chain(d.func)[-1], CallMacro
+            )
+            # would like to do
+            # ... in [compile, template]
+            # but
+            # from pydsl.frontend import compile, template
+            # cause cyclic error
+        ]
+        if decorator_list:
+            rst = Function.full_init(self, node)
+            return reduce(
+                lambda op, f: f(op),
+                [self.visit(decorator) for decorator in decorator_list],
+                rst,
+            )
+        else:
+            return Function.full_init(self, node)
 
     def visit_Module(self, node: ast.Module) -> SubtreeOut:
         module = Module()

--- a/src/pydsl/transform.py
+++ b/src/pydsl/transform.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
+import ast
 from collections.abc import Callable, Iterable
+from functools import reduce
 from typing import List, Optional
 
 from mlir.dialects import transform
@@ -79,10 +81,24 @@ def linalg_fuse(
     )
 
 
+def attr_setter(attr_name: str, value):
+    """
+    Returns a function that sets an MLIR operation attribute.
+
+    - attr_name: str, the name of the attribute
+    - value: the MLIR attribute value
+    """
+
+    def decorator(mlir):
+        op = get_operator(mlir)
+        op.attributes[attr_name] = value
+        return mlir
+
+    return decorator
+
+
 @CallMacro.generate()
-def tag(
-    visitor: "ToMLIRBase", mlir: Compiled[OpView], attr_name: Evaluated[str]
-) -> OpView:
+def tag(visitor: ToMLIRBase, attr_name: Evaluated[str]) -> Evaluated[Callable]:
     """
     Tags the `mlir` MLIR operation with a MLIR unit attribute with name
     `attr_name`.
@@ -92,29 +108,38 @@ def tag(
       with the unit attribute
     - `attr_name`: str. The name of the unit attribute
     """
-    target = get_operator(mlir)
-
-    if type(attr_name) is not str:
-        raise TypeError("Attribute name is not a string")
-
-    target.attributes[attr_name] = UnitAttr.get()
-    return mlir
+    return attr_setter(attr_name, UnitAttr.get())
 
 
 @CallMacro.generate()
 def int_attr(
-    visitor: "ToMLIRBase",
-    mlir: Compiled[OpView],
-    attr_name: Evaluated[str],
-    value: Evaluated[int],
+    visitor: ToMLIRBase, attr_name: Evaluated[str], value: Evaluated[int]
+) -> Evaluated[Callable]:
+    return attr_setter(attr_name, IntegerAttr.get(IndexType.get(), value))
+
+
+@CallMacro.generate(with_callsite=True)
+def decorate_next(
+    visitor: ToMLIRBase, self: ast.AST, *decorators: List[Evaluated[Callable]]
 ) -> OpView:
-    target = get_operator(mlir)
+    parent = getattr(self, "parent", None)
+    if not isinstance(parent, ast.Expr):
+        raise SyntaxError(
+            "decorate_next must appear as a free-standing expression."
+        )
 
-    if type(attr_name) is not str:
-        raise TypeError("Attribute name is not a string")
-    target.attributes[attr_name] = IntegerAttr.get(IndexType.get(), value)
+    next_stmt = getattr(parent, "next_line", None)
+    if next_stmt is None:
+        raise SyntaxError(
+            "decorate_next could not find a valid next statement."
+        )
 
-    return mlir
+    # Visit the statement and apply decorators
+    rst = visitor.visit(next_stmt)
+    rst = reduce(lambda op, f: f(op), decorators, rst)
+
+    visitor.skip_next = True
+    return rst
 
 
 @CallMacro.generate()

--- a/tests/e2e/test_algorithms.py
+++ b/tests/e2e/test_algorithms.py
@@ -15,6 +15,7 @@ import pydsl.tensor as tensor
 from pydsl.tensor import Tensor
 from pydsl.scf import range
 from pydsl.transform import (
+    decorate_next,
     fuse,
     fuse_into,
     int_attr,
@@ -48,9 +49,9 @@ def explicit_affine_heat(
 ):
     a: F32 = 2.0
     b: F32 = 0.125
-    """@tag("tile")"""
+    decorate_next(tag("tile"))
     for t in arange(S(tsteps)):
-        """@tag("fuse_1")"""
+        decorate_next(tag("fuse_1"))
         for i in arange(1, S(n) - 1):
             for j in arange(1, S(n) - 1):
                 for k in arange(1, S(n) - 1):
@@ -76,7 +77,7 @@ def explicit_affine_heat(
                         + A[am(D(i), D(j), D(k))]
                     )
 
-        """@tag("fuse_2")"""
+        decorate_next(tag("fuse_2"))
         for i in arange(1, S(n) - 1):
             for j in arange(1, S(n) - 1):
                 for k in arange(1, S(n) - 1):
@@ -116,9 +117,9 @@ def implicit_affine_heat(
 ) -> Tuple[MemRefRank3F32, MemRefRank3F32]:
     a: F32 = 2.0
     b: F32 = 0.125
-    """@tag("tile")"""
+    decorate_next(tag("tile"))
     for _ in arange(tsteps):
-        """@tag("fuse_1")"""
+        decorate_next(tag("fuse_1"))
         for i in arange(1, n - 1):
             for j in arange(1, n - 1):
                 for k in arange(1, n - 1):
@@ -134,7 +135,7 @@ def implicit_affine_heat(
                         + A[i, j, k - 1]
                     )
 
-        """@tag("fuse_2")"""
+        decorate_next(tag("fuse_2"))
         for i in arange(1, n - 1):
             for j in arange(1, n - 1):
                 for k in arange(1, n - 1):
@@ -232,20 +233,20 @@ def correlation(
 ) -> F32:
     a: F32 = 1.0
     b: F32 = 0.0
-    """@tag("tile_and_distribute")"""
+    decorate_next(tag("tile_and_distribute"))
     for arg3 in arange(S(v1) - 1):
-        """@int_attr("set", 0)"""
+        decorate_next(int_attr("set", 0))
         arg2[am(D(arg3), D(arg3))] = a
         for arg4 in arange(D(arg3) + 1, S(v1)):
-            """@int_attr("set", 1)"""
+            decorate_next(int_attr("set", 1))
             arg2[am(D(arg4), D(arg3))] = b
             for arg5 in arange(S(v0)):
-                """@recursively(lambda x: int_attr(x, "set", 2))"""
-                arg2[am(D(arg4), D(arg3))] = arg2[am(D(arg4), D(arg3))] + (
-                    arg1[am(D(arg5), D(arg3))] * arg1[am(D(arg5), D(arg4))]
-                )
+                with recursively(int_attr("set", 2)):
+                    arg2[am(D(arg4), D(arg3))] = arg2[am(D(arg4), D(arg3))] + (
+                        arg1[am(D(arg5), D(arg3))] * arg1[am(D(arg5), D(arg4))]
+                    )
 
-            with recursively(lambda x: int_attr(x, "set", 3)):
+            with recursively(int_attr("set", 3)):
                 arg2[am(D(arg3), D(arg4))] = arg2[am(D(arg4), D(arg3))]
 
     arg1[am(S(v1) - 1, S(v1) - 1)] = a
@@ -278,29 +279,29 @@ def lu_transform_seq(targ: AnyOp):
 
 
 def lu(v0: Index, arg1: MemRefRank2F64):
-    """@tag("tile")"""
+    decorate_next(tag("tile"))
     for arg2 in arange(S(v0)):
-        """@tag("fuse_4")"""
+        decorate_next(tag("fuse_4"))
         for arg3 in arange(D(arg2)):
-            """@tag("fuse_1")"""
+            decorate_next(tag("fuse_1"))
             for arg4 in arange(D(arg3)):
                 arg1[am(D(arg2), D(arg3))] = arg1[am(D(arg2), D(arg3))] - (
                     arg1[am(D(arg2), D(arg4))] * arg1[am(D(arg4), D(arg3))]
                 )
 
-            """@tag("fuse_target1")"""
+            decorate_next(tag("fuse_target1"))
             v1 = arg1[am(D(arg3), D(arg3))]
 
-            """@tag("fuse_target2")"""
+            decorate_next(tag("fuse_target2"))
             v2 = arg1[am(D(arg2), D(arg3))]
 
-            """@tag("fuse_target3")"""
+            decorate_next(tag("fuse_target3"))
             v3 = v2 / v1
 
-            """@tag("fuse_target4")"""
+            decorate_next(tag("fuse_target4"))
             arg1[am(D(arg2), D(arg3))] = v3
 
-        """@tag("fuse_3")"""
+        decorate_next(tag("fuse_3"))
         for arg3 in arange(D(arg2), S(v0)):
             for arg4 in arange(D(arg2)):
                 arg1[am(D(arg2), D(arg3))] = arg1[am(D(arg2), D(arg3))] - (

--- a/tests/e2e/test_frontend.py
+++ b/tests/e2e/test_frontend.py
@@ -1,7 +1,7 @@
 from pydsl.affine import affine_range as arange
 from pydsl.frontend import CTarget, compile
 from pydsl.memref import DYNAMIC, MemRef
-from pydsl.transform import tile, match_tag as match, tag
+from pydsl.transform import decorate_next, tile, match_tag as match, tag
 from pydsl.type import F32, AnyOp, Index
 from helper import failed_from, run
 
@@ -33,7 +33,7 @@ from helper import failed_from, run
 #             u2: MemRef[F32, DYNAMIC],
 #             v2: MemRef[F32, DYNAMIC],
 #         ) -> None:
-#             """@tag("tile1")"""
+#             decorate_next(tag("tile1"))
 #             for i in arange(n):
 #                 for j in arange(n):
 #                     A[i, j] = A[i, j] + u1[i] * v1[j] + u2[i] * v2[j]

--- a/tests/e2e/test_transform.py
+++ b/tests/e2e/test_transform.py
@@ -12,6 +12,7 @@ from pydsl.memref import MemRef
 from pydsl.scf import range as srange
 from pydsl.transform import (
     cse,
+    decorate_next,
     int_attr,
     loop_coalesce,
     outline_loop,
@@ -25,7 +26,7 @@ from pydsl.type import F32, AnyOp, UInt32
 def test_multiple_recursively_tag():
     @compile(globals())
     def identity():
-        with recursively(lambda x: tag(x, "mytag")):
+        with recursively(tag("mytag")):
             a: F32 = 0.0
             b: F32 = 1.0
 
@@ -41,7 +42,7 @@ def test_multiple_recursively_tag():
 def test_multiple_recursively_int_attr():
     @compile(globals())
     def identity():
-        with recursively(lambda x: int_attr(x, "myintattr", 3)):
+        with recursively(int_attr("myintattr", 3)):
             a: F32 = 0.0
             b: F32 = 1.0
 
@@ -66,10 +67,9 @@ def test_cse_then_coalesce():
         override_fields=False,
     )
     class Module:
-        """@tag("coalesce_func")"""
-
+        @tag("coalesce_func")
         def f(m: MemRef[UInt32, 4, 4]):
-            """@tag("coalesce_loop")"""
+            decorate_next(tag("coalesce_loop"))
             for i in srange(4):
                 for j in srange(4):
                     m[i, j] = i + j
@@ -104,7 +104,7 @@ def test_outline_loop():
     def f(m: MemRef[UInt32, 4, 4]):
         m[1, 1] = 3
 
-        """@tag("outlined")"""
+        decorate_next(tag("outlined"))
         for i in arange(4):
             for j in arange(4):
                 m[i, j] = i + j


### PR DESCRIPTION
fixes #112 

replaced the syntax `"""@tag(...)"""`
with `@tag("coalesce_func")` and `decorate_next(tag("coalesce_loop"))`